### PR TITLE
Add `SetToken` support

### DIFF
--- a/generate/templates/Client.mustache
+++ b/generate/templates/Client.mustache
@@ -42,7 +42,7 @@ namespace {{packageName}}
         /// </summary>
         public void SetToken(string token)
         {
-            if(string.IsNullOrEmpty(token))
+            if (string.IsNullOrEmpty(token))
             {
                 throw new ArgumentNullException("Token cannot be empty");
             }

--- a/generate/templates/libraries/httpclient/ApiClient.mustache
+++ b/generate/templates/libraries/httpclient/ApiClient.mustache
@@ -165,12 +165,12 @@ namespace {{packageName}}.Client
     {
         public readonly Configuration Configuration;
 
-        private readonly object tokenLock = new object();
+        private readonly object _tokenLock = new object();
 
         private string _token;
         public void SetToken(string token)
         {
-            lock(tokenLock)
+            lock (_tokenLock)
             {
                 _token = token;
             }
@@ -262,7 +262,7 @@ namespace {{packageName}}.Client
 
             HttpRequestMessage request = new HttpRequestMessage(method, builder.GetFullUri());
 
-            lock(tokenLock)
+            lock (_tokenLock)
             {
                 if (!string.IsNullOrEmpty(_token))
                 {

--- a/src/Vault/Client/ApiClient.cs
+++ b/src/Vault/Client/ApiClient.cs
@@ -167,12 +167,12 @@ namespace Vault.Client
     {
         public readonly Configuration Configuration;
 
-        private readonly object tokenLock = new object();
+        private readonly object _tokenLock = new object();
 
         private string _token;
         public void SetToken(string token)
         {
-            lock(tokenLock)
+            lock (_tokenLock)
             {
                 _token = token;
             }
@@ -263,7 +263,7 @@ namespace Vault.Client
 
             HttpRequestMessage request = new HttpRequestMessage(method, builder.GetFullUri());
 
-            lock(tokenLock)
+            lock (_tokenLock)
             {
                 if (!string.IsNullOrEmpty(_token))
                 {

--- a/src/Vault/VaultClient.cs
+++ b/src/Vault/VaultClient.cs
@@ -44,7 +44,7 @@ namespace Vault
         /// </summary>
         public void SetToken(string token)
         {
-            if(string.IsNullOrEmpty(token))
+            if (string.IsNullOrEmpty(token))
             {
                 throw new ArgumentNullException("Token cannot be empty");
             }


### PR DESCRIPTION
- Adding a SetToken support so the user can use `vaultClient.SetToken(root);`
- Add `ApiClient` obj to VaultClient
- Token locking mechanism