### PR TITLE
`Api.mustache` cleanup

### DIFF
--- a/generate/templates/libraries/httpclient/api.mustache
+++ b/generate/templates/libraries/httpclient/api.mustache
@@ -1,7 +1,6 @@
 {{>partial_header}}
 
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using {{packageName}}.Client;

--- a/src/Vault/Api/Auth.cs
+++ b/src/Vault/Api/Auth.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Vault.Client;

--- a/src/Vault/Api/Identity.cs
+++ b/src/Vault/Api/Identity.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Vault.Client;

--- a/src/Vault/Api/Secrets.cs
+++ b/src/Vault/Api/Secrets.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Vault.Client;

--- a/src/Vault/Api/System.cs
+++ b/src/Vault/Api/System.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Vault.Client;


### PR DESCRIPTION
- Removing unused namespaces
- Removing `localVar` prefix from variables
- Removing `Vault.Client.` on most objects 