### PR TITLE
Fix exception factory

### DIFF
--- a/generate/templates/ApiException.mustache
+++ b/generate/templates/ApiException.mustache
@@ -7,7 +7,7 @@ namespace {{packageName}}.Client
     /// <summary>
     /// API Exception
     /// </summary>
-    {{>visibility}} class ApiException : Exception
+    {{>visibility}} class {{packageName}}ApiException : Exception
     {
         /// <summary>
         /// Gets or sets the error code (HTTP status code)
@@ -28,28 +28,28 @@ namespace {{packageName}}.Client
         public Multimap<string, string> Headers { get; private set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// Initializes a new instance of the <see cref="{{packageName}}ApiException"/> class.
         /// </summary>
-        public ApiException() { }
+        public {{packageName}}ApiException() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// Initializes a new instance of the <see cref="{{packageName}}ApiException"/> class.
         /// </summary>
         /// <param name="errorCode">HTTP status code.</param>
         /// <param name="message">Error message.</param>
-        public ApiException(int errorCode, string message) : base(message)
+        public {{packageName}}ApiException(int errorCode, string message) : base(message)
         {
             this.ErrorCode = errorCode;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// Initializes a new instance of the <see cref="{{packageName}}ApiException"/> class.
         /// </summary>
         /// <param name="errorCode">HTTP status code.</param>
         /// <param name="message">Error message.</param>
         /// <param name="errorContent">Error content.</param>
         /// <param name="headers">HTTP Headers.</param>
-        public ApiException(int errorCode, string message, object errorContent = null, Multimap<string, string> headers = null) : base(message)
+        public {{packageName}}ApiException(int errorCode, string message, object errorContent = null, Multimap<string, string> headers = null) : base(message)
         {
             this.ErrorCode = errorCode;
             this.ErrorContent = errorContent;

--- a/generate/templates/Configuration.mustache
+++ b/generate/templates/Configuration.mustache
@@ -46,14 +46,14 @@ namespace {{packageName}}.Client
             var status = (int)response.StatusCode;
             if (status >= 400)
             {
-                return new ApiException(status,
+                return new {{packageName}}ApiException(status,
                     string.Format("Error calling {0}: {1}", methodName, response.RawContent),
                     response.RawContent, response.Headers);
             }
             {{^netStandard}}
             if (status == 0)
             {
-                return new ApiException(status,
+                return new {{packageName}}ApiException(status,
                     string.Format("Error calling {0}: {1}", methodName, response.ErrorText), response.ErrorText);
             }
             {{/netStandard}}

--- a/generate/templates/libraries/httpclient/ApiClient.mustache
+++ b/generate/templates/libraries/httpclient/ApiClient.mustache
@@ -140,7 +140,7 @@ namespace {{packageName}}.Client
             }
             catch (Exception e)
             {
-                throw new ApiException(500, e.Message);
+                throw new {{packageName}}ApiException(500, e.Message);
             }
         }
 

--- a/generate/templates/libraries/httpclient/api.mustache
+++ b/generate/templates/libraries/httpclient/api.mustache
@@ -24,7 +24,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <remarks>
         /// {{notes}}
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
         {{/allParams}}/// <returns>ApiResponse of {{returnType}}{{^returnType}}Object(void){{/returnType}}</returns>
         {{#isDeprecated}}
@@ -50,7 +50,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <remarks>
         /// {{notes}}
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#allParams}}
         /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
         {{/allParams}}
@@ -87,7 +87,7 @@ namespace {{packageName}}.{{apiPackage}}
             this.Configuration = apiClient.Configuration;
             this.Client = apiClient;
             this.AsynchronousClient = apiClient;
-            this.ExceptionFactory = {{packageName}}.Client.Configuration.DefaultExceptionFactory;
+            this.ExceptionFactory = Configuration.DefaultExceptionFactory;
         }
 
         {{#supportsAsync}}
@@ -138,7 +138,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <summary>
         /// {{summary}} {{notes}}
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
         {{/allParams}}/// <returns>ApiResponse of {{returnType}}{{^returnType}}Object(void){{/returnType}}</returns>
         {{#isDeprecated}}
@@ -151,7 +151,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{^vendorExtensions.x-csharp-value-type}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
-                throw new ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
+                throw new {{packageName}}ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
 
             {{/vendorExtensions.x-csharp-value-type}}
             {{/required}}
@@ -337,7 +337,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <summary>
         /// {{summary}} {{notes}}
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#allParams}}
         /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
         {{/allParams}}
@@ -353,7 +353,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{^vendorExtensions.x-csharp-value-type}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
-                throw new ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
+                throw new {{packageName}}ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
 
             {{/vendorExtensions.x-csharp-value-type}}
             {{/required}}

--- a/src/Vault/Api/Auth.cs
+++ b/src/Vault/Api/Auth.cs
@@ -29,7 +29,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAlicloudRoleRole(string role);
@@ -39,7 +39,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAppIdMapAppIdKey(string key);
@@ -49,7 +49,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAppIdMapUserIdKey(string key);
@@ -59,7 +59,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleName(string roleName);
@@ -69,7 +69,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameBindSecretId(string roleName);
@@ -79,7 +79,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameBoundCidrList(string roleName);
@@ -89,7 +89,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNamePeriod(string roleName);
@@ -99,7 +99,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNamePolicies(string roleName);
@@ -109,7 +109,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy(string roleName);
@@ -119,7 +119,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs(string roleName);
@@ -129,7 +129,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdDestroy(string roleName);
@@ -139,7 +139,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdNumUses(string roleName);
@@ -149,7 +149,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdTtl(string roleName);
@@ -159,7 +159,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenBoundCidrs(string roleName);
@@ -169,7 +169,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenMaxTtl(string roleName);
@@ -179,7 +179,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenNumUses(string roleName);
@@ -189,7 +189,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenTtl(string roleName);
@@ -199,7 +199,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsConfigCertificateCertName(string certName);
@@ -209,7 +209,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsConfigClient();
         /// <summary>
@@ -218,7 +218,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsConfigStsAccountId(string accountId);
@@ -228,7 +228,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsConfigTidyIdentityAccesslist();
         /// <summary>
@@ -237,7 +237,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsConfigTidyIdentityWhitelist();
         /// <summary>
@@ -246,7 +246,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsConfigTidyRoletagBlacklist();
         /// <summary>
@@ -255,7 +255,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsConfigTidyRoletagDenylist();
         /// <summary>
@@ -264,7 +264,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsIdentityAccesslistInstanceId(string instanceId);
@@ -274,7 +274,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsIdentityWhitelistInstanceId(string instanceId);
@@ -284,7 +284,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsRoleRole(string role);
@@ -294,7 +294,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsRoletagBlacklistRoleTag(string roleTag);
@@ -304,7 +304,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAwsRoletagDenylistRoleTag(string roleTag);
@@ -314,7 +314,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAzureConfig();
         /// <summary>
@@ -323,7 +323,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthAzureRoleName(string name);
@@ -333,7 +333,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthCertCertsName(string name);
@@ -343,7 +343,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthCertCrlsName(string name);
@@ -353,7 +353,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthCfConfig();
         /// <summary>
@@ -362,7 +362,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthCfRolesRole(string role);
@@ -372,7 +372,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthGcpRoleName(string name);
@@ -382,7 +382,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthGithubMapTeamsKey(string key);
@@ -392,7 +392,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthGithubMapUsersKey(string key);
@@ -402,7 +402,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthJwtRoleName(string name);
@@ -412,7 +412,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthKerberosGroupsName(string name);
@@ -422,7 +422,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthKubernetesRoleName(string name);
@@ -432,7 +432,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthLdapGroupsName(string name);
@@ -442,7 +442,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthLdapUsersName(string name);
@@ -452,7 +452,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthOciConfig();
         /// <summary>
@@ -461,7 +461,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthOciRoleRole(string role);
@@ -471,7 +471,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthOidcRoleName(string name);
@@ -481,7 +481,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthOktaGroupsName(string name);
@@ -491,7 +491,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthOktaUsersName(string name);
@@ -501,7 +501,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthRadiusUsersName(string name);
@@ -511,7 +511,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthTokenRolesRoleName(string roleName);
@@ -521,7 +521,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAuthUserpassUsersUsername(string username);
@@ -531,7 +531,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAlicloudRole(string list);
@@ -541,7 +541,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAlicloudRoleRole(string role);
@@ -551,7 +551,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAlicloudRoles(string list);
@@ -561,7 +561,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAppIdMapAppId(string list = default(string));
@@ -571,7 +571,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAppIdMapAppIdKey(string key);
@@ -581,7 +581,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAppIdMapUserId(string list = default(string));
@@ -591,7 +591,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAppIdMapUserIdKey(string key);
@@ -601,7 +601,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRole(string list);
@@ -611,7 +611,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleName(string roleName);
@@ -621,7 +621,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameBindSecretId(string roleName);
@@ -631,7 +631,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameBoundCidrList(string roleName);
@@ -641,7 +641,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameLocalSecretIds(string roleName);
@@ -651,7 +651,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNamePeriod(string roleName);
@@ -661,7 +661,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNamePolicies(string roleName);
@@ -671,7 +671,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameRoleId(string roleName);
@@ -681,7 +681,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -692,7 +692,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameSecretIdBoundCidrs(string roleName);
@@ -702,7 +702,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameSecretIdNumUses(string roleName);
@@ -712,7 +712,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameSecretIdTtl(string roleName);
@@ -722,7 +722,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameTokenBoundCidrs(string roleName);
@@ -732,7 +732,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameTokenMaxTtl(string roleName);
@@ -742,7 +742,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameTokenNumUses(string roleName);
@@ -752,7 +752,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthApproleRoleRoleNameTokenTtl(string roleName);
@@ -762,7 +762,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigCertificateCertName(string certName);
@@ -772,7 +772,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigCertificates(string list);
@@ -782,7 +782,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigClient();
         /// <summary>
@@ -791,7 +791,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigIdentity();
         /// <summary>
@@ -800,7 +800,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigSts(string list);
@@ -810,7 +810,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigStsAccountId(string accountId);
@@ -820,7 +820,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigTidyIdentityAccesslist();
         /// <summary>
@@ -829,7 +829,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigTidyIdentityWhitelist();
         /// <summary>
@@ -838,7 +838,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigTidyRoletagBlacklist();
         /// <summary>
@@ -847,7 +847,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsConfigTidyRoletagDenylist();
         /// <summary>
@@ -856,7 +856,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsIdentityAccesslist(string list);
@@ -866,7 +866,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsIdentityAccesslistInstanceId(string instanceId);
@@ -876,7 +876,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsIdentityWhitelist(string list);
@@ -886,7 +886,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsIdentityWhitelistInstanceId(string instanceId);
@@ -896,7 +896,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsRole(string list);
@@ -906,7 +906,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsRoleRole(string role);
@@ -916,7 +916,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsRoles(string list);
@@ -926,7 +926,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsRoletagBlacklist(string list);
@@ -936,7 +936,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsRoletagBlacklistRoleTag(string roleTag);
@@ -946,7 +946,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsRoletagDenylist(string list);
@@ -956,7 +956,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAwsRoletagDenylistRoleTag(string roleTag);
@@ -966,7 +966,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAzureConfig();
         /// <summary>
@@ -975,7 +975,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAzureRole(string list);
@@ -985,7 +985,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthAzureRoleName(string name);
@@ -995,7 +995,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthCentrifyConfig();
         /// <summary>
@@ -1004,7 +1004,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthCertCerts(string list);
@@ -1014,7 +1014,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthCertCertsName(string name);
@@ -1024,7 +1024,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthCertCrlsName(string name);
@@ -1034,7 +1034,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthCfConfig();
         /// <summary>
@@ -1043,7 +1043,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthCfRoles(string list);
@@ -1053,7 +1053,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthCfRolesRole(string role);
@@ -1063,7 +1063,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGcpConfig();
         /// <summary>
@@ -1072,7 +1072,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGcpRole(string list);
@@ -1082,7 +1082,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGcpRoleName(string name);
@@ -1092,7 +1092,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGcpRoles(string list);
@@ -1102,7 +1102,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGithubConfig();
         /// <summary>
@@ -1111,7 +1111,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGithubMapTeams(string list = default(string));
@@ -1121,7 +1121,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGithubMapTeamsKey(string key);
@@ -1131,7 +1131,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGithubMapUsers(string list = default(string));
@@ -1141,7 +1141,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthGithubMapUsersKey(string key);
@@ -1151,7 +1151,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthJwtConfig();
         /// <summary>
@@ -1160,7 +1160,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthJwtOidcCallback();
         /// <summary>
@@ -1169,7 +1169,7 @@ namespace Vault.Api
         /// <remarks>
         /// The list will contain the names of the roles.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthJwtRole(string list);
@@ -1179,7 +1179,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthJwtRoleName(string name);
@@ -1189,7 +1189,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKerberosConfig();
         /// <summary>
@@ -1198,7 +1198,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKerberosConfigLdap();
         /// <summary>
@@ -1207,7 +1207,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKerberosGroups(string list);
@@ -1217,7 +1217,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKerberosGroupsName(string name);
@@ -1227,7 +1227,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKerberosLogin();
         /// <summary>
@@ -1236,7 +1236,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKubernetesConfig();
         /// <summary>
@@ -1245,7 +1245,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKubernetesRole(string list);
@@ -1255,7 +1255,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthKubernetesRoleName(string name);
@@ -1265,7 +1265,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthLdapConfig();
         /// <summary>
@@ -1274,7 +1274,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthLdapGroups(string list);
@@ -1284,7 +1284,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthLdapGroupsName(string name);
@@ -1294,7 +1294,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthLdapUsers(string list);
@@ -1304,7 +1304,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthLdapUsersName(string name);
@@ -1314,7 +1314,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOciConfig();
         /// <summary>
@@ -1323,7 +1323,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOciRole(string list);
@@ -1333,7 +1333,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOciRoleRole(string role);
@@ -1343,7 +1343,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOidcConfig();
         /// <summary>
@@ -1352,7 +1352,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOidcOidcCallback();
         /// <summary>
@@ -1361,7 +1361,7 @@ namespace Vault.Api
         /// <remarks>
         /// The list will contain the names of the roles.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOidcRole(string list);
@@ -1371,7 +1371,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOidcRoleName(string name);
@@ -1381,7 +1381,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOktaConfig();
         /// <summary>
@@ -1390,7 +1390,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOktaGroups(string list);
@@ -1400,7 +1400,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOktaGroupsName(string name);
@@ -1410,7 +1410,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOktaUsers(string list);
@@ -1420,7 +1420,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOktaUsersName(string name);
@@ -1430,7 +1430,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nonce">Nonce provided during a login request to retrieve the number verification challenge for the matching request.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthOktaVerifyNonce(string nonce);
@@ -1440,7 +1440,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthRadiusConfig();
         /// <summary>
@@ -1449,7 +1449,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthRadiusUsers(string list);
@@ -1459,7 +1459,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthRadiusUsersName(string name);
@@ -1469,7 +1469,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthTokenAccessors(string list);
@@ -1479,7 +1479,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthTokenLookup();
         /// <summary>
@@ -1488,7 +1488,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthTokenLookupSelf();
         /// <summary>
@@ -1497,7 +1497,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthTokenRoles(string list);
@@ -1507,7 +1507,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthTokenRolesRoleName(string roleName);
@@ -1517,7 +1517,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthUserpassUsers(string list);
@@ -1527,7 +1527,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAuthUserpassUsersUsername(string username);
@@ -1537,7 +1537,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAlicloudLogin(AlicloudLoginRequest alicloudLoginRequest = default(AlicloudLoginRequest));
@@ -1547,7 +1547,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1558,7 +1558,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAppIdLogin(AppIdLoginRequest appIdLoginRequest = default(AppIdLoginRequest));
@@ -1568,7 +1568,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appId">The unique app ID</param>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1579,7 +1579,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="appIdMapAppIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1590,7 +1590,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="appIdMapUserIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1601,7 +1601,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="approleLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthApproleLogin(ApproleLoginRequest approleLoginRequest = default(ApproleLoginRequest));
@@ -1611,7 +1611,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1622,7 +1622,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBindSecretIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1633,7 +1633,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBoundCidrListRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1644,7 +1644,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleCustomSecretIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1655,7 +1655,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePeriodRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1666,7 +1666,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePoliciesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1677,7 +1677,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRoleIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1688,7 +1688,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1699,7 +1699,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1710,7 +1710,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1721,7 +1721,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdBoundCidrsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1732,7 +1732,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1743,7 +1743,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1754,7 +1754,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdNumUsesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1765,7 +1765,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdTtlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1776,7 +1776,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenBoundCidrsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1787,7 +1787,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenMaxTtlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1798,7 +1798,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenNumUsesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1809,7 +1809,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenTtlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1820,7 +1820,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthApproleTidySecretId();
         /// <summary>
@@ -1829,7 +1829,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="awsConfigCertificateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1840,7 +1840,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigClientRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsConfigClient(AwsConfigClientRequest awsConfigClientRequest = default(AwsConfigClientRequest));
@@ -1850,7 +1850,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigIdentityRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsConfigIdentity(AwsConfigIdentityRequest awsConfigIdentityRequest = default(AwsConfigIdentityRequest));
@@ -1860,7 +1860,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsConfigRotateRoot();
         /// <summary>
@@ -1869,7 +1869,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="awsConfigStsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1880,7 +1880,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityAccesslistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsConfigTidyIdentityAccesslist(AwsConfigTidyIdentityAccesslistRequest awsConfigTidyIdentityAccesslistRequest = default(AwsConfigTidyIdentityAccesslistRequest));
@@ -1890,7 +1890,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityWhitelistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsConfigTidyIdentityWhitelist(AwsConfigTidyIdentityWhitelistRequest awsConfigTidyIdentityWhitelistRequest = default(AwsConfigTidyIdentityWhitelistRequest));
@@ -1900,7 +1900,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagBlacklistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsConfigTidyRoletagBlacklist(AwsConfigTidyRoletagBlacklistRequest awsConfigTidyRoletagBlacklistRequest = default(AwsConfigTidyRoletagBlacklistRequest));
@@ -1910,7 +1910,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagDenylistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsConfigTidyRoletagDenylist(AwsConfigTidyRoletagDenylistRequest awsConfigTidyRoletagDenylistRequest = default(AwsConfigTidyRoletagDenylistRequest));
@@ -1920,7 +1920,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsLogin(AwsLoginRequest awsLoginRequest = default(AwsLoginRequest));
@@ -1930,7 +1930,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1941,7 +1941,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleTagRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1952,7 +1952,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsRoletagBlacklistRoleTag(string roleTag);
@@ -1962,7 +1962,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsRoletagDenylistRoleTag(string roleTag);
@@ -1972,7 +1972,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityAccesslistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsTidyIdentityAccesslist(AwsTidyIdentityAccesslistRequest awsTidyIdentityAccesslistRequest = default(AwsTidyIdentityAccesslistRequest));
@@ -1982,7 +1982,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityWhitelistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsTidyIdentityWhitelist(AwsTidyIdentityWhitelistRequest awsTidyIdentityWhitelistRequest = default(AwsTidyIdentityWhitelistRequest));
@@ -1992,7 +1992,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagBlacklistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsTidyRoletagBlacklist(AwsTidyRoletagBlacklistRequest awsTidyRoletagBlacklistRequest = default(AwsTidyRoletagBlacklistRequest));
@@ -2002,7 +2002,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagDenylistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAwsTidyRoletagDenylist(AwsTidyRoletagDenylistRequest awsTidyRoletagDenylistRequest = default(AwsTidyRoletagDenylistRequest));
@@ -2012,7 +2012,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAzureConfig(AzureConfigRequest azureConfigRequest = default(AzureConfigRequest));
@@ -2022,7 +2022,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthAzureLogin(AzureLoginRequest azureLoginRequest = default(AzureLoginRequest));
@@ -2032,7 +2032,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2043,7 +2043,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthCentrifyConfig(CentrifyConfigRequest centrifyConfigRequest = default(CentrifyConfigRequest));
@@ -2053,7 +2053,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthCentrifyLogin(CentrifyLoginRequest centrifyLoginRequest = default(CentrifyLoginRequest));
@@ -2063,7 +2063,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCertsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2074,7 +2074,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthCertConfig(CertConfigRequest certConfigRequest = default(CertConfigRequest));
@@ -2084,7 +2084,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCrlsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2095,7 +2095,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthCertLogin(CertLoginRequest certLoginRequest = default(CertLoginRequest));
@@ -2105,7 +2105,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthCfConfig(CfConfigRequest cfConfigRequest = default(CfConfigRequest));
@@ -2115,7 +2115,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthCfLogin(CfLoginRequest cfLoginRequest = default(CfLoginRequest));
@@ -2125,7 +2125,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cfRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2136,7 +2136,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthGcpConfig(GcpConfigRequest gcpConfigRequest = default(GcpConfigRequest));
@@ -2146,7 +2146,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthGcpLogin(GcpLoginRequest gcpLoginRequest = default(GcpLoginRequest));
@@ -2156,7 +2156,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2167,7 +2167,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleLabelsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2178,7 +2178,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleServiceAccountsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2189,7 +2189,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthGithubConfig(GithubConfigRequest githubConfigRequest = default(GithubConfigRequest));
@@ -2199,7 +2199,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthGithubLogin(GithubLoginRequest githubLoginRequest = default(GithubLoginRequest));
@@ -2209,7 +2209,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="githubMapTeamsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2220,7 +2220,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="githubMapUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2231,7 +2231,7 @@ namespace Vault.Api
         /// <remarks>
         /// The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthJwtConfig(JwtConfigRequest jwtConfigRequest = default(JwtConfigRequest));
@@ -2241,7 +2241,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthJwtLogin(JwtLoginRequest jwtLoginRequest = default(JwtLoginRequest));
@@ -2251,7 +2251,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcAuthUrlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthJwtOidcAuthUrl(JwtOidcAuthUrlRequest jwtOidcAuthUrlRequest = default(JwtOidcAuthUrlRequest));
@@ -2261,7 +2261,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcCallbackRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthJwtOidcCallback(JwtOidcCallbackRequest jwtOidcCallbackRequest = default(JwtOidcCallbackRequest));
@@ -2271,7 +2271,7 @@ namespace Vault.Api
         /// <remarks>
         /// A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="jwtRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2282,7 +2282,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthKerberosConfig(KerberosConfigRequest kerberosConfigRequest = default(KerberosConfigRequest));
@@ -2292,7 +2292,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigLdapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthKerberosConfigLdap(KerberosConfigLdapRequest kerberosConfigLdapRequest = default(KerberosConfigLdapRequest));
@@ -2302,7 +2302,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="kerberosGroupsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2313,7 +2313,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthKerberosLogin(KerberosLoginRequest kerberosLoginRequest = default(KerberosLoginRequest));
@@ -2323,7 +2323,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthKubernetesConfig(KubernetesConfigRequest kubernetesConfigRequest = default(KubernetesConfigRequest));
@@ -2333,7 +2333,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthKubernetesLogin(KubernetesLoginRequest kubernetesLoginRequest = default(KubernetesLoginRequest));
@@ -2343,7 +2343,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="kubernetesRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2354,7 +2354,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ldapConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthLdapConfig(LdapConfigRequest ldapConfigRequest = default(LdapConfigRequest));
@@ -2364,7 +2364,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="ldapGroupsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2375,7 +2375,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">DN (distinguished name) to be used for login.</param>
         /// <param name="ldapLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2386,7 +2386,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="ldapUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2397,7 +2397,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ociConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthOciConfig(OciConfigRequest ociConfigRequest = default(OciConfigRequest));
@@ -2407,7 +2407,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2418,7 +2418,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2429,7 +2429,7 @@ namespace Vault.Api
         /// <remarks>
         /// The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthOidcConfig(OidcConfigRequest oidcConfigRequest = default(OidcConfigRequest));
@@ -2439,7 +2439,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthOidcLogin(OidcLoginRequest oidcLoginRequest = default(OidcLoginRequest));
@@ -2449,7 +2449,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcAuthUrlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthOidcOidcAuthUrl(OidcOidcAuthUrlRequest oidcOidcAuthUrlRequest = default(OidcOidcAuthUrlRequest));
@@ -2459,7 +2459,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcCallbackRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthOidcOidcCallback(OidcOidcCallbackRequest oidcOidcCallbackRequest = default(OidcOidcCallbackRequest));
@@ -2469,7 +2469,7 @@ namespace Vault.Api
         /// <remarks>
         /// A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="oidcRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2480,7 +2480,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oktaConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthOktaConfig(OktaConfigRequest oktaConfigRequest = default(OktaConfigRequest));
@@ -2490,7 +2490,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="oktaGroupsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2501,7 +2501,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username to be used for login.</param>
         /// <param name="oktaLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2512,7 +2512,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="oktaUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2523,7 +2523,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthRadiusConfig(RadiusConfigRequest radiusConfigRequest = default(RadiusConfigRequest));
@@ -2533,7 +2533,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthRadiusLogin(RadiusLoginRequest radiusLoginRequest = default(RadiusLoginRequest));
@@ -2543,7 +2543,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlusername">Username to be used for login. (URL parameter)</param>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2554,7 +2554,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="radiusUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2565,7 +2565,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenCreate();
         /// <summary>
@@ -2574,7 +2574,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenCreateOrphan();
         /// <summary>
@@ -2583,7 +2583,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenCreateRoleName(string roleName);
@@ -2593,7 +2593,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenLookup(TokenLookupRequest tokenLookupRequest = default(TokenLookupRequest));
@@ -2603,7 +2603,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenLookupAccessor(TokenLookupAccessorRequest tokenLookupAccessorRequest = default(TokenLookupAccessorRequest));
@@ -2613,7 +2613,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupSelfRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenLookupSelf(TokenLookupSelfRequest tokenLookupSelfRequest = default(TokenLookupSelfRequest));
@@ -2623,7 +2623,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenRenew(TokenRenewRequest tokenRenewRequest = default(TokenRenewRequest));
@@ -2633,7 +2633,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenRenewAccessor(TokenRenewAccessorRequest tokenRenewAccessorRequest = default(TokenRenewAccessorRequest));
@@ -2643,7 +2643,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewSelfRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenRenewSelf(TokenRenewSelfRequest tokenRenewSelfRequest = default(TokenRenewSelfRequest));
@@ -2653,7 +2653,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenRevoke(TokenRevokeRequest tokenRevokeRequest = default(TokenRevokeRequest));
@@ -2663,7 +2663,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenRevokeAccessor(TokenRevokeAccessorRequest tokenRevokeAccessorRequest = default(TokenRevokeAccessorRequest));
@@ -2673,7 +2673,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeOrphanRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenRevokeOrphan(TokenRevokeOrphanRequest tokenRevokeOrphanRequest = default(TokenRevokeOrphanRequest));
@@ -2683,7 +2683,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenRevokeSelf();
         /// <summary>
@@ -2692,7 +2692,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="tokenRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2703,7 +2703,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAuthTokenTidy();
         /// <summary>
@@ -2712,7 +2712,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username of the user.</param>
         /// <param name="userpassLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2723,7 +2723,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2734,7 +2734,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPasswordRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2745,7 +2745,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPoliciesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2766,7 +2766,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2778,7 +2778,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2790,7 +2790,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2802,7 +2802,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2814,7 +2814,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2826,7 +2826,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2838,7 +2838,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2850,7 +2850,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2862,7 +2862,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2874,7 +2874,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2886,7 +2886,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2898,7 +2898,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2910,7 +2910,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2922,7 +2922,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2934,7 +2934,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2946,7 +2946,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2958,7 +2958,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2970,7 +2970,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2982,7 +2982,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthAwsConfigClientAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2993,7 +2993,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3005,7 +3005,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyIdentityAccesslistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3016,7 +3016,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyIdentityWhitelistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3027,7 +3027,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyRoletagBlacklistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3038,7 +3038,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyRoletagDenylistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3049,7 +3049,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3061,7 +3061,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3073,7 +3073,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3085,7 +3085,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3097,7 +3097,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3109,7 +3109,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3120,7 +3120,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3132,7 +3132,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3144,7 +3144,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3156,7 +3156,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthCfConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3167,7 +3167,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3179,7 +3179,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3191,7 +3191,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3203,7 +3203,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3215,7 +3215,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3227,7 +3227,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3239,7 +3239,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3251,7 +3251,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3263,7 +3263,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3275,7 +3275,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAuthOciConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3286,7 +3286,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3298,7 +3298,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3310,7 +3310,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3322,7 +3322,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3334,7 +3334,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3346,7 +3346,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3358,7 +3358,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3370,7 +3370,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3382,7 +3382,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3394,7 +3394,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3406,7 +3406,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3418,7 +3418,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3430,7 +3430,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3442,7 +3442,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3454,7 +3454,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3466,7 +3466,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3478,7 +3478,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3490,7 +3490,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3502,7 +3502,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3514,7 +3514,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3526,7 +3526,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3538,7 +3538,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3550,7 +3550,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3563,7 +3563,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3575,7 +3575,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3587,7 +3587,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3599,7 +3599,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3611,7 +3611,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3623,7 +3623,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3635,7 +3635,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3647,7 +3647,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3659,7 +3659,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3671,7 +3671,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthAwsConfigClientAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3682,7 +3682,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthAwsConfigIdentityAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3693,7 +3693,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3705,7 +3705,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3717,7 +3717,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthAwsConfigTidyIdentityAccesslistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3728,7 +3728,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthAwsConfigTidyIdentityWhitelistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3739,7 +3739,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthAwsConfigTidyRoletagBlacklistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3750,7 +3750,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthAwsConfigTidyRoletagDenylistAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3761,7 +3761,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3773,7 +3773,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3785,7 +3785,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3797,7 +3797,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3809,7 +3809,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3821,7 +3821,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3833,7 +3833,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3845,7 +3845,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3857,7 +3857,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3869,7 +3869,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3881,7 +3881,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3893,7 +3893,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3904,7 +3904,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3916,7 +3916,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3928,7 +3928,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthCentrifyConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3939,7 +3939,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3951,7 +3951,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3963,7 +3963,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3975,7 +3975,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthCfConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3986,7 +3986,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3998,7 +3998,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4010,7 +4010,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthGcpConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4021,7 +4021,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4033,7 +4033,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4045,7 +4045,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4057,7 +4057,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthGithubConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4068,7 +4068,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4080,7 +4080,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4092,7 +4092,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4104,7 +4104,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4116,7 +4116,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthJwtConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4127,7 +4127,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthJwtOidcCallbackAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4138,7 +4138,7 @@ namespace Vault.Api
         /// <remarks>
         /// The list will contain the names of the roles.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4150,7 +4150,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4162,7 +4162,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthKerberosConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4173,7 +4173,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthKerberosConfigLdapAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4184,7 +4184,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4196,7 +4196,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4208,7 +4208,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthKerberosLoginAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4219,7 +4219,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthKubernetesConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4230,7 +4230,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4242,7 +4242,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4254,7 +4254,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthLdapConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4265,7 +4265,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4277,7 +4277,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4289,7 +4289,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4301,7 +4301,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4313,7 +4313,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthOciConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4324,7 +4324,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4336,7 +4336,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4348,7 +4348,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthOidcConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4359,7 +4359,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthOidcOidcCallbackAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4370,7 +4370,7 @@ namespace Vault.Api
         /// <remarks>
         /// The list will contain the names of the roles.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4382,7 +4382,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4394,7 +4394,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthOktaConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4405,7 +4405,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4417,7 +4417,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4429,7 +4429,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4441,7 +4441,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4453,7 +4453,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nonce">Nonce provided during a login request to retrieve the number verification challenge for the matching request.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4465,7 +4465,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthRadiusConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4476,7 +4476,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4488,7 +4488,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4500,7 +4500,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4512,7 +4512,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthTokenLookupAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4523,7 +4523,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAuthTokenLookupSelfAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4534,7 +4534,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4546,7 +4546,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4558,7 +4558,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4570,7 +4570,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4582,7 +4582,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4594,7 +4594,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4607,7 +4607,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4619,7 +4619,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appId">The unique app ID</param>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4632,7 +4632,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="appIdMapAppIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4645,7 +4645,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="appIdMapUserIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4658,7 +4658,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="approleLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4670,7 +4670,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4683,7 +4683,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBindSecretIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4696,7 +4696,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBoundCidrListRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4709,7 +4709,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleCustomSecretIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4722,7 +4722,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePeriodRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4735,7 +4735,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePoliciesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4748,7 +4748,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRoleIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4761,7 +4761,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4774,7 +4774,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4787,7 +4787,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4800,7 +4800,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdBoundCidrsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4813,7 +4813,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4826,7 +4826,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4839,7 +4839,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdNumUsesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4852,7 +4852,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdTtlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4865,7 +4865,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenBoundCidrsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4878,7 +4878,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenMaxTtlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4891,7 +4891,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenNumUsesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4904,7 +4904,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenTtlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4917,7 +4917,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAuthApproleTidySecretIdAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4928,7 +4928,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="awsConfigCertificateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4941,7 +4941,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigClientRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4953,7 +4953,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigIdentityRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4965,7 +4965,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAuthAwsConfigRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4976,7 +4976,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="awsConfigStsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4989,7 +4989,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityAccesslistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5001,7 +5001,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityWhitelistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5013,7 +5013,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagBlacklistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5025,7 +5025,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagDenylistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5037,7 +5037,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5049,7 +5049,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5062,7 +5062,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleTagRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5075,7 +5075,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5087,7 +5087,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5099,7 +5099,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityAccesslistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5111,7 +5111,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityWhitelistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5123,7 +5123,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagBlacklistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5135,7 +5135,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagDenylistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5147,7 +5147,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5159,7 +5159,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5171,7 +5171,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5184,7 +5184,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5196,7 +5196,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5208,7 +5208,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCertsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5221,7 +5221,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5233,7 +5233,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCrlsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5246,7 +5246,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5258,7 +5258,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5270,7 +5270,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5282,7 +5282,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cfRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5295,7 +5295,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5307,7 +5307,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5319,7 +5319,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5332,7 +5332,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleLabelsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5345,7 +5345,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleServiceAccountsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5358,7 +5358,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5370,7 +5370,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5382,7 +5382,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="githubMapTeamsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5395,7 +5395,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="githubMapUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5408,7 +5408,7 @@ namespace Vault.Api
         /// <remarks>
         /// The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5420,7 +5420,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5432,7 +5432,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcAuthUrlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5444,7 +5444,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcCallbackRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5456,7 +5456,7 @@ namespace Vault.Api
         /// <remarks>
         /// A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="jwtRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5469,7 +5469,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5481,7 +5481,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigLdapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5493,7 +5493,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="kerberosGroupsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5506,7 +5506,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5518,7 +5518,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5530,7 +5530,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5542,7 +5542,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="kubernetesRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5555,7 +5555,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ldapConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5567,7 +5567,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="ldapGroupsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5580,7 +5580,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">DN (distinguished name) to be used for login.</param>
         /// <param name="ldapLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5593,7 +5593,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="ldapUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5606,7 +5606,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ociConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5618,7 +5618,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5631,7 +5631,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5644,7 +5644,7 @@ namespace Vault.Api
         /// <remarks>
         /// The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5656,7 +5656,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5668,7 +5668,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcAuthUrlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5680,7 +5680,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcCallbackRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5692,7 +5692,7 @@ namespace Vault.Api
         /// <remarks>
         /// A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="oidcRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5705,7 +5705,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oktaConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5717,7 +5717,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="oktaGroupsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5730,7 +5730,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username to be used for login.</param>
         /// <param name="oktaLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5743,7 +5743,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="oktaUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5756,7 +5756,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5768,7 +5768,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5780,7 +5780,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlusername">Username to be used for login. (URL parameter)</param>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5793,7 +5793,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="radiusUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5806,7 +5806,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAuthTokenCreateAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5817,7 +5817,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAuthTokenCreateOrphanAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5828,7 +5828,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5840,7 +5840,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5852,7 +5852,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5864,7 +5864,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupSelfRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5876,7 +5876,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5888,7 +5888,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5900,7 +5900,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewSelfRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5912,7 +5912,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5924,7 +5924,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5936,7 +5936,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeOrphanRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5948,7 +5948,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAuthTokenRevokeSelfAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5959,7 +5959,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="tokenRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5972,7 +5972,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAuthTokenTidyAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5983,7 +5983,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username of the user.</param>
         /// <param name="userpassLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5996,7 +5996,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6009,7 +6009,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPasswordRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6022,7 +6022,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPoliciesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6053,7 +6053,7 @@ namespace Vault.Api
             this.Configuration = apiClient.Configuration;
             this.Client = apiClient;
             this.AsynchronousClient = apiClient;
-            this.ExceptionFactory = Vault.Client.Configuration.DefaultExceptionFactory;
+            this.ExceptionFactory = Configuration.DefaultExceptionFactory;
         }
 
         /// <summary>
@@ -6101,14 +6101,14 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAlicloudRoleRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAlicloudRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAlicloudRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6143,7 +6143,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6151,7 +6151,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAlicloudRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAlicloudRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6187,14 +6187,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single app-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAppIdMapAppIdKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapAppIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapAppIdKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6229,7 +6229,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single app-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6237,7 +6237,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapAppIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapAppIdKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6273,14 +6273,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single user-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAppIdMapUserIdKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapUserIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapUserIdKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6315,7 +6315,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single user-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6323,7 +6323,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapUserIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthAppIdMapUserIdKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6359,14 +6359,14 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleName(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6401,7 +6401,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6409,7 +6409,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6445,14 +6445,14 @@ namespace Vault.Api
         /// <summary>
         /// Impose secret_id to be presented during login using this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameBindSecretId(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBindSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBindSecretId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6487,7 +6487,7 @@ namespace Vault.Api
         /// <summary>
         /// Impose secret_id to be presented during login using this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6495,7 +6495,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBindSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBindSecretId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6531,14 +6531,14 @@ namespace Vault.Api
         /// <summary>
         /// Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameBoundCidrList(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBoundCidrList");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBoundCidrList");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6573,7 +6573,7 @@ namespace Vault.Api
         /// <summary>
         /// Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6581,7 +6581,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBoundCidrList");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameBoundCidrList");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6617,14 +6617,14 @@ namespace Vault.Api
         /// <summary>
         /// Updates the value of &#39;period&#39; on the role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNamePeriod(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePeriod");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePeriod");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6659,7 +6659,7 @@ namespace Vault.Api
         /// <summary>
         /// Updates the value of &#39;period&#39; on the role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6667,7 +6667,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePeriod");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePeriod");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6703,14 +6703,14 @@ namespace Vault.Api
         /// <summary>
         /// Policies of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNamePolicies(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePolicies");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6745,7 +6745,7 @@ namespace Vault.Api
         /// <summary>
         /// Policies of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6753,7 +6753,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNamePolicies");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6789,14 +6789,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6831,7 +6831,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6839,7 +6839,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdAccessorDestroy");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6875,14 +6875,14 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6917,7 +6917,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6925,7 +6925,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdBoundCidrs");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6961,14 +6961,14 @@ namespace Vault.Api
         /// <summary>
         /// Invalidate an issued secret_id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdDestroy(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdDestroy");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7003,7 +7003,7 @@ namespace Vault.Api
         /// <summary>
         /// Invalidate an issued secret_id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7011,7 +7011,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdDestroy");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7047,14 +7047,14 @@ namespace Vault.Api
         /// <summary>
         /// Use limit of the SecretID generated against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdNumUses(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdNumUses");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7089,7 +7089,7 @@ namespace Vault.Api
         /// <summary>
         /// Use limit of the SecretID generated against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7097,7 +7097,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdNumUses");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7133,14 +7133,14 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using &#39;role/&lt;role_name&gt;/secret-id&#39; or &#39;role/&lt;role_name&gt;/custom-secret-id&#39; endpoints. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameSecretIdTtl(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7175,7 +7175,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using &#39;role/&lt;role_name&gt;/secret-id&#39; or &#39;role/&lt;role_name&gt;/custom-secret-id&#39; endpoints. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7183,7 +7183,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameSecretIdTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7219,14 +7219,14 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenBoundCidrs(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenBoundCidrs");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7261,7 +7261,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7269,7 +7269,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenBoundCidrs");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7305,14 +7305,14 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenMaxTtl(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenMaxTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenMaxTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7347,7 +7347,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7355,7 +7355,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenMaxTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenMaxTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7391,14 +7391,14 @@ namespace Vault.Api
         /// <summary>
         /// Number of times issued tokens can be used 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenNumUses(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenNumUses");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7433,7 +7433,7 @@ namespace Vault.Api
         /// <summary>
         /// Number of times issued tokens can be used 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7441,7 +7441,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenNumUses");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7477,14 +7477,14 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthApproleRoleRoleNameTokenTtl(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7519,7 +7519,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7527,7 +7527,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthApproleRoleRoleNameTokenTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7563,14 +7563,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsConfigCertificateCertName(string certName)
         {
             // verify the required parameter 'certName' is set
             if (certName == null)
-                throw new ApiException(400, "Missing required parameter 'certName' when calling Auth->DeleteAuthAwsConfigCertificateCertName");
+                throw new VaultApiException(400, "Missing required parameter 'certName' when calling Auth->DeleteAuthAwsConfigCertificateCertName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7605,7 +7605,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7613,7 +7613,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'certName' is set
             if (certName == null)
-                throw new ApiException(400, "Missing required parameter 'certName' when calling Auth->DeleteAuthAwsConfigCertificateCertName");
+                throw new VaultApiException(400, "Missing required parameter 'certName' when calling Auth->DeleteAuthAwsConfigCertificateCertName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7649,7 +7649,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsConfigClient()
         {
@@ -7685,7 +7685,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthAwsConfigClientAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7723,14 +7723,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsConfigStsAccountId(string accountId)
         {
             // verify the required parameter 'accountId' is set
             if (accountId == null)
-                throw new ApiException(400, "Missing required parameter 'accountId' when calling Auth->DeleteAuthAwsConfigStsAccountId");
+                throw new VaultApiException(400, "Missing required parameter 'accountId' when calling Auth->DeleteAuthAwsConfigStsAccountId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7765,7 +7765,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7773,7 +7773,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'accountId' is set
             if (accountId == null)
-                throw new ApiException(400, "Missing required parameter 'accountId' when calling Auth->DeleteAuthAwsConfigStsAccountId");
+                throw new VaultApiException(400, "Missing required parameter 'accountId' when calling Auth->DeleteAuthAwsConfigStsAccountId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7809,7 +7809,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsConfigTidyIdentityAccesslist()
         {
@@ -7845,7 +7845,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyIdentityAccesslistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7883,7 +7883,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsConfigTidyIdentityWhitelist()
         {
@@ -7919,7 +7919,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyIdentityWhitelistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7957,7 +7957,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsConfigTidyRoletagBlacklist()
         {
@@ -7993,7 +7993,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyRoletagBlacklistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8031,7 +8031,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsConfigTidyRoletagDenylist()
         {
@@ -8067,7 +8067,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthAwsConfigTidyRoletagDenylistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8105,14 +8105,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsIdentityAccesslistInstanceId(string instanceId)
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityAccesslistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityAccesslistInstanceId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8147,7 +8147,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8155,7 +8155,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityAccesslistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityAccesslistInstanceId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8191,14 +8191,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsIdentityWhitelistInstanceId(string instanceId)
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityWhitelistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityWhitelistInstanceId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8233,7 +8233,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8241,7 +8241,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityWhitelistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->DeleteAuthAwsIdentityWhitelistInstanceId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8277,14 +8277,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsRoleRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAwsRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAwsRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8319,7 +8319,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8327,7 +8327,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAwsRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthAwsRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8363,14 +8363,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsRoletagBlacklistRoleTag(string roleTag)
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagBlacklistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagBlacklistRoleTag");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8405,7 +8405,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8413,7 +8413,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagBlacklistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagBlacklistRoleTag");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8449,14 +8449,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAwsRoletagDenylistRoleTag(string roleTag)
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagDenylistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagDenylistRoleTag");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8491,7 +8491,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8499,7 +8499,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagDenylistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->DeleteAuthAwsRoletagDenylistRoleTag");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8535,7 +8535,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAzureConfig()
         {
@@ -8571,7 +8571,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8609,14 +8609,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthAzureRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthAzureRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthAzureRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8651,7 +8651,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8659,7 +8659,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthAzureRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthAzureRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8695,14 +8695,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthCertCertsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCertsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCertsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8737,7 +8737,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8745,7 +8745,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCertsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCertsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8781,14 +8781,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage Certificate Revocation Lists checked during authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthCertCrlsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCrlsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCrlsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8823,7 +8823,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage Certificate Revocation Lists checked during authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8831,7 +8831,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCrlsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthCertCrlsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8867,7 +8867,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthCfConfig()
         {
@@ -8903,7 +8903,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthCfConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8941,14 +8941,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthCfRolesRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthCfRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthCfRolesRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8983,7 +8983,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8991,7 +8991,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthCfRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthCfRolesRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9027,14 +9027,14 @@ namespace Vault.Api
         /// <summary>
         /// Create a GCP role with associated policies and required attributes. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthGcpRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthGcpRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthGcpRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9069,7 +9069,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a GCP role with associated policies and required attributes. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9077,7 +9077,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthGcpRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthGcpRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9113,14 +9113,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single teams mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthGithubMapTeamsKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapTeamsKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapTeamsKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9155,7 +9155,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single teams mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9163,7 +9163,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapTeamsKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapTeamsKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9199,14 +9199,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single users mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthGithubMapUsersKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapUsersKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapUsersKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9241,7 +9241,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single users mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9249,7 +9249,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapUsersKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->DeleteAuthGithubMapUsersKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9285,14 +9285,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthJwtRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthJwtRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthJwtRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9327,7 +9327,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9335,7 +9335,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthJwtRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthJwtRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9371,14 +9371,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthKerberosGroupsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKerberosGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKerberosGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9413,7 +9413,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9421,7 +9421,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKerberosGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKerberosGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9457,14 +9457,14 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthKubernetesRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKubernetesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKubernetesRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9499,7 +9499,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9507,7 +9507,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKubernetesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthKubernetesRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9543,14 +9543,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthLdapGroupsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9585,7 +9585,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9593,7 +9593,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9629,14 +9629,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthLdapUsersName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9671,7 +9671,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9679,7 +9679,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthLdapUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9715,7 +9715,7 @@ namespace Vault.Api
         /// <summary>
         /// Manages the configuration for the Vault Auth Plugin. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthOciConfig()
         {
@@ -9751,7 +9751,7 @@ namespace Vault.Api
         /// <summary>
         /// Manages the configuration for the Vault Auth Plugin. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAuthOciConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9789,14 +9789,14 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthOciRoleRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthOciRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthOciRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9831,7 +9831,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9839,7 +9839,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthOciRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->DeleteAuthOciRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9875,14 +9875,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthOidcRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOidcRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9917,7 +9917,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9925,7 +9925,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOidcRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9961,14 +9961,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthOktaGroupsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10003,7 +10003,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10011,7 +10011,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10047,14 +10047,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthOktaUsersName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10089,7 +10089,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10097,7 +10097,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthOktaUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10133,14 +10133,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthRadiusUsersName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthRadiusUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthRadiusUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10175,7 +10175,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10183,7 +10183,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthRadiusUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->DeleteAuthRadiusUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10219,14 +10219,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthTokenRolesRoleName(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthTokenRolesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthTokenRolesRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10261,7 +10261,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10269,7 +10269,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthTokenRolesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->DeleteAuthTokenRolesRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10305,14 +10305,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAuthUserpassUsersUsername(string username)
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->DeleteAuthUserpassUsersUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->DeleteAuthUserpassUsersUsername");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10347,7 +10347,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10355,7 +10355,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->DeleteAuthUserpassUsersUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->DeleteAuthUserpassUsersUsername");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10391,14 +10391,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAlicloudRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10433,7 +10433,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10441,7 +10441,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10477,14 +10477,14 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAlicloudRoleRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAlicloudRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAlicloudRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10519,7 +10519,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10527,7 +10527,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAlicloudRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAlicloudRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10563,14 +10563,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAlicloudRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10605,7 +10605,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10613,7 +10613,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAlicloudRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10649,7 +10649,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for app-id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAppIdMapAppId(string list = default(string))
@@ -10690,7 +10690,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for app-id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10733,14 +10733,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single app-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAppIdMapAppIdKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapAppIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapAppIdKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10775,7 +10775,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single app-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10783,7 +10783,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapAppIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapAppIdKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10819,7 +10819,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for user-id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAppIdMapUserId(string list = default(string))
@@ -10860,7 +10860,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for user-id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10903,14 +10903,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single user-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAppIdMapUserIdKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapUserIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapUserIdKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10945,7 +10945,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single user-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10953,7 +10953,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapUserIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthAppIdMapUserIdKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10989,14 +10989,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11031,7 +11031,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11039,7 +11039,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11075,14 +11075,14 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleName(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11117,7 +11117,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11125,7 +11125,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11161,14 +11161,14 @@ namespace Vault.Api
         /// <summary>
         /// Impose secret_id to be presented during login using this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameBindSecretId(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBindSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBindSecretId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11203,7 +11203,7 @@ namespace Vault.Api
         /// <summary>
         /// Impose secret_id to be presented during login using this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11211,7 +11211,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBindSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBindSecretId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11247,14 +11247,14 @@ namespace Vault.Api
         /// <summary>
         /// Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameBoundCidrList(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBoundCidrList");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBoundCidrList");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11289,7 +11289,7 @@ namespace Vault.Api
         /// <summary>
         /// Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11297,7 +11297,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBoundCidrList");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameBoundCidrList");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11333,14 +11333,14 @@ namespace Vault.Api
         /// <summary>
         /// Enables cluster local secret IDs 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameLocalSecretIds(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameLocalSecretIds");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameLocalSecretIds");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11375,7 +11375,7 @@ namespace Vault.Api
         /// <summary>
         /// Enables cluster local secret IDs 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11383,7 +11383,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameLocalSecretIds");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameLocalSecretIds");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11419,14 +11419,14 @@ namespace Vault.Api
         /// <summary>
         /// Updates the value of &#39;period&#39; on the role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNamePeriod(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePeriod");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePeriod");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11461,7 +11461,7 @@ namespace Vault.Api
         /// <summary>
         /// Updates the value of &#39;period&#39; on the role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11469,7 +11469,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePeriod");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePeriod");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11505,14 +11505,14 @@ namespace Vault.Api
         /// <summary>
         /// Policies of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNamePolicies(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePolicies");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11547,7 +11547,7 @@ namespace Vault.Api
         /// <summary>
         /// Policies of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11555,7 +11555,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNamePolicies");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11591,14 +11591,14 @@ namespace Vault.Api
         /// <summary>
         /// Returns the &#39;role_id&#39; of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameRoleId(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameRoleId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameRoleId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11633,7 +11633,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the &#39;role_id&#39; of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11641,7 +11641,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameRoleId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameRoleId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11677,7 +11677,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a SecretID against this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11685,11 +11685,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
 
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11725,7 +11725,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a SecretID against this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11734,11 +11734,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
 
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthApproleRoleRoleNameSecretId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11775,14 +11775,14 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameSecretIdBoundCidrs(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdBoundCidrs");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11817,7 +11817,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11825,7 +11825,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdBoundCidrs");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11861,14 +11861,14 @@ namespace Vault.Api
         /// <summary>
         /// Use limit of the SecretID generated against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameSecretIdNumUses(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdNumUses");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11903,7 +11903,7 @@ namespace Vault.Api
         /// <summary>
         /// Use limit of the SecretID generated against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11911,7 +11911,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdNumUses");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11947,14 +11947,14 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using &#39;role/&lt;role_name&gt;/secret-id&#39; or &#39;role/&lt;role_name&gt;/custom-secret-id&#39; endpoints. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameSecretIdTtl(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11989,7 +11989,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using &#39;role/&lt;role_name&gt;/secret-id&#39; or &#39;role/&lt;role_name&gt;/custom-secret-id&#39; endpoints. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11997,7 +11997,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameSecretIdTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12033,14 +12033,14 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameTokenBoundCidrs(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenBoundCidrs");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12075,7 +12075,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12083,7 +12083,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenBoundCidrs");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12119,14 +12119,14 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameTokenMaxTtl(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenMaxTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenMaxTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12161,7 +12161,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12169,7 +12169,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenMaxTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenMaxTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12205,14 +12205,14 @@ namespace Vault.Api
         /// <summary>
         /// Number of times issued tokens can be used 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameTokenNumUses(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenNumUses");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12247,7 +12247,7 @@ namespace Vault.Api
         /// <summary>
         /// Number of times issued tokens can be used 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12255,7 +12255,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenNumUses");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12291,14 +12291,14 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthApproleRoleRoleNameTokenTtl(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12333,7 +12333,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12341,7 +12341,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthApproleRoleRoleNameTokenTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12377,14 +12377,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigCertificateCertName(string certName)
         {
             // verify the required parameter 'certName' is set
             if (certName == null)
-                throw new ApiException(400, "Missing required parameter 'certName' when calling Auth->GetAuthAwsConfigCertificateCertName");
+                throw new VaultApiException(400, "Missing required parameter 'certName' when calling Auth->GetAuthAwsConfigCertificateCertName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12419,7 +12419,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12427,7 +12427,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'certName' is set
             if (certName == null)
-                throw new ApiException(400, "Missing required parameter 'certName' when calling Auth->GetAuthAwsConfigCertificateCertName");
+                throw new VaultApiException(400, "Missing required parameter 'certName' when calling Auth->GetAuthAwsConfigCertificateCertName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12463,14 +12463,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigCertificates(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigCertificates");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigCertificates");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12505,7 +12505,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12513,7 +12513,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigCertificates");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigCertificates");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12549,7 +12549,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigClient()
         {
@@ -12585,7 +12585,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthAwsConfigClientAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -12623,7 +12623,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigIdentity()
         {
@@ -12659,7 +12659,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthAwsConfigIdentityAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -12697,14 +12697,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigSts(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigSts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigSts");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12739,7 +12739,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12747,7 +12747,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigSts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsConfigSts");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12783,14 +12783,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigStsAccountId(string accountId)
         {
             // verify the required parameter 'accountId' is set
             if (accountId == null)
-                throw new ApiException(400, "Missing required parameter 'accountId' when calling Auth->GetAuthAwsConfigStsAccountId");
+                throw new VaultApiException(400, "Missing required parameter 'accountId' when calling Auth->GetAuthAwsConfigStsAccountId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12825,7 +12825,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12833,7 +12833,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'accountId' is set
             if (accountId == null)
-                throw new ApiException(400, "Missing required parameter 'accountId' when calling Auth->GetAuthAwsConfigStsAccountId");
+                throw new VaultApiException(400, "Missing required parameter 'accountId' when calling Auth->GetAuthAwsConfigStsAccountId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12869,7 +12869,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigTidyIdentityAccesslist()
         {
@@ -12905,7 +12905,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthAwsConfigTidyIdentityAccesslistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -12943,7 +12943,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigTidyIdentityWhitelist()
         {
@@ -12979,7 +12979,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthAwsConfigTidyIdentityWhitelistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -13017,7 +13017,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigTidyRoletagBlacklist()
         {
@@ -13053,7 +13053,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthAwsConfigTidyRoletagBlacklistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -13091,7 +13091,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsConfigTidyRoletagDenylist()
         {
@@ -13127,7 +13127,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthAwsConfigTidyRoletagDenylistAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -13165,14 +13165,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsIdentityAccesslist(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityAccesslist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityAccesslist");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13207,7 +13207,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13215,7 +13215,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityAccesslist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityAccesslist");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13251,14 +13251,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsIdentityAccesslistInstanceId(string instanceId)
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityAccesslistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityAccesslistInstanceId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13293,7 +13293,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13301,7 +13301,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityAccesslistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityAccesslistInstanceId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13337,14 +13337,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsIdentityWhitelist(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityWhitelist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityWhitelist");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13379,7 +13379,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13387,7 +13387,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityWhitelist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsIdentityWhitelist");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13423,14 +13423,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsIdentityWhitelistInstanceId(string instanceId)
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityWhitelistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityWhitelistInstanceId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13465,7 +13465,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="instanceId">EC2 instance ID. A successful login operation from an EC2 instance gets cached in this accesslist, keyed off of instance ID.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13473,7 +13473,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'instanceId' is set
             if (instanceId == null)
-                throw new ApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityWhitelistInstanceId");
+                throw new VaultApiException(400, "Missing required parameter 'instanceId' when calling Auth->GetAuthAwsIdentityWhitelistInstanceId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13509,14 +13509,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13551,7 +13551,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13559,7 +13559,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13595,14 +13595,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsRoleRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAwsRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAwsRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13637,7 +13637,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13645,7 +13645,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAwsRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthAwsRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13681,14 +13681,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13723,7 +13723,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13731,7 +13731,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13767,14 +13767,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsRoletagBlacklist(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagBlacklist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagBlacklist");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13809,7 +13809,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13817,7 +13817,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagBlacklist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagBlacklist");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13853,14 +13853,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsRoletagBlacklistRoleTag(string roleTag)
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagBlacklistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagBlacklistRoleTag");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13895,7 +13895,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13903,7 +13903,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagBlacklistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagBlacklistRoleTag");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13939,14 +13939,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsRoletagDenylist(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagDenylist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagDenylist");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13981,7 +13981,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13989,7 +13989,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagDenylist");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAwsRoletagDenylist");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14025,14 +14025,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAwsRoletagDenylistRoleTag(string roleTag)
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagDenylistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagDenylistRoleTag");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14067,7 +14067,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14075,7 +14075,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagDenylistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->GetAuthAwsRoletagDenylistRoleTag");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14111,7 +14111,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAzureConfig()
         {
@@ -14147,7 +14147,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -14185,14 +14185,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAzureRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAzureRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAzureRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14227,7 +14227,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14235,7 +14235,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAzureRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthAzureRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14271,14 +14271,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthAzureRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthAzureRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthAzureRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14313,7 +14313,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14321,7 +14321,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthAzureRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthAzureRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14357,7 +14357,7 @@ namespace Vault.Api
         /// <summary>
         /// This path allows you to configure the centrify auth provider to interact with the Centrify Identity Services Platform for authenticating users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthCentrifyConfig()
         {
@@ -14393,7 +14393,7 @@ namespace Vault.Api
         /// <summary>
         /// This path allows you to configure the centrify auth provider to interact with the Centrify Identity Services Platform for authenticating users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthCentrifyConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -14431,14 +14431,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthCertCerts(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCertCerts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCertCerts");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14473,7 +14473,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14481,7 +14481,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCertCerts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCertCerts");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14517,14 +14517,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthCertCertsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCertsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCertsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14559,7 +14559,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14567,7 +14567,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCertsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCertsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14603,14 +14603,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage Certificate Revocation Lists checked during authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthCertCrlsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCrlsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCrlsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14645,7 +14645,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage Certificate Revocation Lists checked during authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14653,7 +14653,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCrlsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthCertCrlsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14689,7 +14689,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthCfConfig()
         {
@@ -14725,7 +14725,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthCfConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -14763,14 +14763,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthCfRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCfRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCfRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14805,7 +14805,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14813,7 +14813,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCfRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthCfRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14849,14 +14849,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthCfRolesRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthCfRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthCfRolesRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14891,7 +14891,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14899,7 +14899,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthCfRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthCfRolesRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14935,7 +14935,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure credentials used to query the GCP IAM API to verify authenticating service accounts 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGcpConfig()
         {
@@ -14971,7 +14971,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure credentials used to query the GCP IAM API to verify authenticating service accounts 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthGcpConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15009,14 +15009,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGcpRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15051,7 +15051,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15059,7 +15059,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15095,14 +15095,14 @@ namespace Vault.Api
         /// <summary>
         /// Create a GCP role with associated policies and required attributes. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGcpRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthGcpRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthGcpRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15137,7 +15137,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a GCP role with associated policies and required attributes. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15145,7 +15145,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthGcpRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthGcpRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15181,14 +15181,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGcpRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15223,7 +15223,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15231,7 +15231,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthGcpRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15267,7 +15267,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGithubConfig()
         {
@@ -15303,7 +15303,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthGithubConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15341,7 +15341,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for teams 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGithubMapTeams(string list = default(string))
@@ -15382,7 +15382,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for teams 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15425,14 +15425,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single teams mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGithubMapTeamsKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapTeamsKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapTeamsKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15467,7 +15467,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single teams mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15475,7 +15475,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapTeamsKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapTeamsKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15511,7 +15511,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for users 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGithubMapUsers(string list = default(string))
@@ -15552,7 +15552,7 @@ namespace Vault.Api
         /// <summary>
         /// Read mappings for users 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15595,14 +15595,14 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single users mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthGithubMapUsersKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapUsersKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapUsersKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15637,7 +15637,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single users mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15645,7 +15645,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapUsersKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->GetAuthGithubMapUsersKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15681,7 +15681,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current JWT authentication backend configuration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthJwtConfig()
         {
@@ -15717,7 +15717,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current JWT authentication backend configuration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthJwtConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15755,7 +15755,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to complete an OIDC login. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthJwtOidcCallback()
         {
@@ -15791,7 +15791,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to complete an OIDC login. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthJwtOidcCallbackAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15829,14 +15829,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. The list will contain the names of the roles.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthJwtRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthJwtRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthJwtRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15871,7 +15871,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. The list will contain the names of the roles.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15879,7 +15879,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthJwtRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthJwtRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15915,14 +15915,14 @@ namespace Vault.Api
         /// <summary>
         /// Read an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthJwtRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthJwtRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthJwtRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15957,7 +15957,7 @@ namespace Vault.Api
         /// <summary>
         /// Read an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15965,7 +15965,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthJwtRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthJwtRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16001,7 +16001,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKerberosConfig()
         {
@@ -16037,7 +16037,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthKerberosConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16075,7 +16075,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKerberosConfigLdap()
         {
@@ -16111,7 +16111,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthKerberosConfigLdapAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16149,14 +16149,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKerberosGroups(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKerberosGroups");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKerberosGroups");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16191,7 +16191,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16199,7 +16199,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKerberosGroups");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKerberosGroups");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16235,14 +16235,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKerberosGroupsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKerberosGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKerberosGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16277,7 +16277,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16285,7 +16285,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKerberosGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKerberosGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16321,7 +16321,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKerberosLogin()
         {
@@ -16357,7 +16357,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthKerberosLoginAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16395,7 +16395,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures the JWT Public Key and Kubernetes API information. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKubernetesConfig()
         {
@@ -16431,7 +16431,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures the JWT Public Key and Kubernetes API information. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthKubernetesConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16469,14 +16469,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKubernetesRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKubernetesRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKubernetesRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16511,7 +16511,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16519,7 +16519,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKubernetesRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthKubernetesRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16555,14 +16555,14 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthKubernetesRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKubernetesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKubernetesRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16597,7 +16597,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16605,7 +16605,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKubernetesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthKubernetesRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16641,7 +16641,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the LDAP server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthLdapConfig()
         {
@@ -16677,7 +16677,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the LDAP server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthLdapConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16715,14 +16715,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthLdapGroups(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapGroups");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapGroups");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16757,7 +16757,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16765,7 +16765,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapGroups");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapGroups");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16801,14 +16801,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthLdapGroupsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16843,7 +16843,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16851,7 +16851,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16887,14 +16887,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthLdapUsers(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapUsers");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16929,7 +16929,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16937,7 +16937,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthLdapUsers");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16973,14 +16973,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthLdapUsersName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17015,7 +17015,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17023,7 +17023,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthLdapUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17059,7 +17059,7 @@ namespace Vault.Api
         /// <summary>
         /// Manages the configuration for the Vault Auth Plugin. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOciConfig()
         {
@@ -17095,7 +17095,7 @@ namespace Vault.Api
         /// <summary>
         /// Manages the configuration for the Vault Auth Plugin. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthOciConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -17133,14 +17133,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOciRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOciRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOciRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17175,7 +17175,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles that are registered with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17183,7 +17183,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOciRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOciRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17219,14 +17219,14 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOciRoleRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthOciRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthOciRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17261,7 +17261,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17269,7 +17269,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthOciRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->GetAuthOciRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17305,7 +17305,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current JWT authentication backend configuration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOidcConfig()
         {
@@ -17341,7 +17341,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current JWT authentication backend configuration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthOidcConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -17379,7 +17379,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to complete an OIDC login. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOidcOidcCallback()
         {
@@ -17415,7 +17415,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to complete an OIDC login. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthOidcOidcCallbackAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -17453,14 +17453,14 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. The list will contain the names of the roles.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOidcRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOidcRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOidcRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17495,7 +17495,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the roles registered with the backend. The list will contain the names of the roles.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17503,7 +17503,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOidcRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOidcRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17539,14 +17539,14 @@ namespace Vault.Api
         /// <summary>
         /// Read an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOidcRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOidcRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17581,7 +17581,7 @@ namespace Vault.Api
         /// <summary>
         /// Read an existing role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17589,7 +17589,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOidcRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17625,7 +17625,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint allows you to configure the Okta and its configuration options.  The Okta organization are the characters at the front of the URL for Okta. Example https://ORG.okta.com 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOktaConfig()
         {
@@ -17661,7 +17661,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint allows you to configure the Okta and its configuration options.  The Okta organization are the characters at the front of the URL for Okta. Example https://ORG.okta.com 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthOktaConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -17699,14 +17699,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOktaGroups(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaGroups");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaGroups");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17741,7 +17741,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17749,7 +17749,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaGroups");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaGroups");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17785,14 +17785,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOktaGroupsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17827,7 +17827,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17835,7 +17835,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17871,14 +17871,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOktaUsers(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaUsers");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17913,7 +17913,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17921,7 +17921,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthOktaUsers");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17957,14 +17957,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOktaUsersName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17999,7 +17999,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18007,7 +18007,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthOktaUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18043,14 +18043,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nonce">Nonce provided during a login request to retrieve the number verification challenge for the matching request.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthOktaVerifyNonce(string nonce)
         {
             // verify the required parameter 'nonce' is set
             if (nonce == null)
-                throw new ApiException(400, "Missing required parameter 'nonce' when calling Auth->GetAuthOktaVerifyNonce");
+                throw new VaultApiException(400, "Missing required parameter 'nonce' when calling Auth->GetAuthOktaVerifyNonce");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18085,7 +18085,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nonce">Nonce provided during a login request to retrieve the number verification challenge for the matching request.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18093,7 +18093,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'nonce' is set
             if (nonce == null)
-                throw new ApiException(400, "Missing required parameter 'nonce' when calling Auth->GetAuthOktaVerifyNonce");
+                throw new VaultApiException(400, "Missing required parameter 'nonce' when calling Auth->GetAuthOktaVerifyNonce");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18129,7 +18129,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the RADIUS server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthRadiusConfig()
         {
@@ -18165,7 +18165,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the RADIUS server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthRadiusConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18203,14 +18203,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthRadiusUsers(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthRadiusUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthRadiusUsers");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18245,7 +18245,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18253,7 +18253,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthRadiusUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthRadiusUsers");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18289,14 +18289,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthRadiusUsersName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthRadiusUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthRadiusUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18331,7 +18331,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18339,7 +18339,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthRadiusUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->GetAuthRadiusUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18375,14 +18375,14 @@ namespace Vault.Api
         /// <summary>
         /// List token accessors, which can then be be used to iterate and discover their properties or revoke them. Because this can be used to cause a denial of service, this endpoint requires &#39;sudo&#39; capability in addition to &#39;list&#39;. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthTokenAccessors(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenAccessors");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenAccessors");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18417,7 +18417,7 @@ namespace Vault.Api
         /// <summary>
         /// List token accessors, which can then be be used to iterate and discover their properties or revoke them. Because this can be used to cause a denial of service, this endpoint requires &#39;sudo&#39; capability in addition to &#39;list&#39;. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18425,7 +18425,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenAccessors");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenAccessors");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18461,7 +18461,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthTokenLookup()
         {
@@ -18497,7 +18497,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthTokenLookupAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18535,7 +18535,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthTokenLookupSelf()
         {
@@ -18571,7 +18571,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAuthTokenLookupSelfAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18609,14 +18609,14 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint lists configured roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthTokenRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18651,7 +18651,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint lists configured roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18659,7 +18659,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthTokenRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18695,14 +18695,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthTokenRolesRoleName(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthTokenRolesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthTokenRolesRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18737,7 +18737,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18745,7 +18745,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthTokenRolesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->GetAuthTokenRolesRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18781,14 +18781,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthUserpassUsers(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthUserpassUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthUserpassUsers");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18823,7 +18823,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18831,7 +18831,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthUserpassUsers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Auth->GetAuthUserpassUsers");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18867,14 +18867,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAuthUserpassUsersUsername(string username)
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->GetAuthUserpassUsersUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->GetAuthUserpassUsersUsername");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18909,7 +18909,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18917,7 +18917,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->GetAuthUserpassUsersUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->GetAuthUserpassUsersUsername");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18953,7 +18953,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates an RAM entity with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAlicloudLogin(AlicloudLoginRequest alicloudLoginRequest = default(AlicloudLoginRequest))
@@ -18992,7 +18992,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates an RAM entity with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19033,7 +19033,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19041,7 +19041,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAlicloudRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAlicloudRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19078,7 +19078,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role as it should appear in Vault.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19087,7 +19087,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAlicloudRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAlicloudRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19125,7 +19125,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with an App ID and User ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAppIdLogin(AppIdLoginRequest appIdLoginRequest = default(AppIdLoginRequest))
@@ -19164,7 +19164,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with an App ID and User ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19205,7 +19205,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with an App ID and User ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appId">The unique app ID</param>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19213,7 +19213,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'appId' is set
             if (appId == null)
-                throw new ApiException(400, "Missing required parameter 'appId' when calling Auth->PostAuthAppIdLoginAppId");
+                throw new VaultApiException(400, "Missing required parameter 'appId' when calling Auth->PostAuthAppIdLoginAppId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19250,7 +19250,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with an App ID and User ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="appId">The unique app ID</param>
         /// <param name="appIdLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19259,7 +19259,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'appId' is set
             if (appId == null)
-                throw new ApiException(400, "Missing required parameter 'appId' when calling Auth->PostAuthAppIdLoginAppId");
+                throw new VaultApiException(400, "Missing required parameter 'appId' when calling Auth->PostAuthAppIdLoginAppId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19297,7 +19297,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single app-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="appIdMapAppIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19305,7 +19305,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapAppIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapAppIdKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19342,7 +19342,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single app-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the app-id mapping</param>
         /// <param name="appIdMapAppIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19351,7 +19351,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapAppIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapAppIdKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19389,7 +19389,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single user-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="appIdMapUserIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19397,7 +19397,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapUserIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapUserIdKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19434,7 +19434,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single user-id mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the user-id mapping</param>
         /// <param name="appIdMapUserIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19443,7 +19443,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapUserIdKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthAppIdMapUserIdKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19481,7 +19481,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="approleLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthApproleLogin(ApproleLoginRequest approleLoginRequest = default(ApproleLoginRequest))
@@ -19520,7 +19520,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="approleLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19561,7 +19561,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19569,7 +19569,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19606,7 +19606,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19615,7 +19615,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19653,7 +19653,7 @@ namespace Vault.Api
         /// <summary>
         /// Impose secret_id to be presented during login using this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBindSecretIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19661,7 +19661,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBindSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBindSecretId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19698,7 +19698,7 @@ namespace Vault.Api
         /// <summary>
         /// Impose secret_id to be presented during login using this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBindSecretIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19707,7 +19707,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBindSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBindSecretId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19745,7 +19745,7 @@ namespace Vault.Api
         /// <summary>
         /// Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBoundCidrListRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19753,7 +19753,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBoundCidrList");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBoundCidrList");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19790,7 +19790,7 @@ namespace Vault.Api
         /// <summary>
         /// Deprecated: Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleBoundCidrListRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19799,7 +19799,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBoundCidrList");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameBoundCidrList");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19837,7 +19837,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign a SecretID of choice against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleCustomSecretIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19845,7 +19845,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameCustomSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameCustomSecretId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19882,7 +19882,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign a SecretID of choice against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleCustomSecretIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19891,7 +19891,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameCustomSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameCustomSecretId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19929,7 +19929,7 @@ namespace Vault.Api
         /// <summary>
         /// Updates the value of &#39;period&#39; on the role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePeriodRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19937,7 +19937,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePeriod");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePeriod");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19974,7 +19974,7 @@ namespace Vault.Api
         /// <summary>
         /// Updates the value of &#39;period&#39; on the role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePeriodRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19983,7 +19983,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePeriod");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePeriod");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20021,7 +20021,7 @@ namespace Vault.Api
         /// <summary>
         /// Policies of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePoliciesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20029,7 +20029,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePolicies");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20066,7 +20066,7 @@ namespace Vault.Api
         /// <summary>
         /// Policies of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRolePoliciesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20075,7 +20075,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNamePolicies");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20113,7 +20113,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the &#39;role_id&#39; of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRoleIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20121,7 +20121,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameRoleId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameRoleId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20158,7 +20158,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the &#39;role_id&#39; of the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleRoleIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20167,7 +20167,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameRoleId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameRoleId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20205,7 +20205,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a SecretID against this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20213,7 +20213,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20250,7 +20250,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a SecretID against this role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20259,7 +20259,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretId");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20297,7 +20297,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20305,7 +20305,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorDestroy");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20342,7 +20342,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20351,7 +20351,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorDestroy");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20389,7 +20389,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20397,7 +20397,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorLookup");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorLookup");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20434,7 +20434,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdAccessorLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20443,7 +20443,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorLookup");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdAccessorLookup");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20481,7 +20481,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdBoundCidrsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20489,7 +20489,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdBoundCidrs");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20526,7 +20526,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated list of CIDR blocks, if set, specifies blocks of IP addresses which can perform the login operation 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdBoundCidrsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20535,7 +20535,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdBoundCidrs");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20573,7 +20573,7 @@ namespace Vault.Api
         /// <summary>
         /// Invalidate an issued secret_id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20581,7 +20581,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdDestroy");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20618,7 +20618,7 @@ namespace Vault.Api
         /// <summary>
         /// Invalidate an issued secret_id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20627,7 +20627,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdDestroy");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdDestroy");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20665,7 +20665,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the properties of an issued secret_id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20673,7 +20673,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdLookup");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdLookup");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20710,7 +20710,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the properties of an issued secret_id 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20719,7 +20719,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdLookup");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdLookup");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20757,7 +20757,7 @@ namespace Vault.Api
         /// <summary>
         /// Use limit of the SecretID generated against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdNumUsesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20765,7 +20765,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdNumUses");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20802,7 +20802,7 @@ namespace Vault.Api
         /// <summary>
         /// Use limit of the SecretID generated against the role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdNumUsesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20811,7 +20811,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdNumUses");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20849,7 +20849,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using &#39;role/&lt;role_name&gt;/secret-id&#39; or &#39;role/&lt;role_name&gt;/custom-secret-id&#39; endpoints. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdTtlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20857,7 +20857,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20894,7 +20894,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, representing the lifetime of the SecretIDs that are generated against the role using &#39;role/&lt;role_name&gt;/secret-id&#39; or &#39;role/&lt;role_name&gt;/custom-secret-id&#39; endpoints. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleSecretIdTtlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20903,7 +20903,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameSecretIdTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20941,7 +20941,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenBoundCidrsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20949,7 +20949,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenBoundCidrs");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20986,7 +20986,7 @@ namespace Vault.Api
         /// <summary>
         /// Comma separated string or list of CIDR blocks. If set, specifies the blocks of IP addresses which can use the returned token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenBoundCidrsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20995,7 +20995,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenBoundCidrs");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenBoundCidrs");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21033,7 +21033,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenMaxTtlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21041,7 +21041,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenMaxTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenMaxTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21078,7 +21078,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the maximum lifetime of the tokens issued by using the SecretIDs that were generated against this role, after which the tokens are not allowed to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenMaxTtlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21087,7 +21087,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenMaxTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenMaxTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21125,7 +21125,7 @@ namespace Vault.Api
         /// <summary>
         /// Number of times issued tokens can be used 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenNumUsesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21133,7 +21133,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenNumUses");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21170,7 +21170,7 @@ namespace Vault.Api
         /// <summary>
         /// Number of times issued tokens can be used 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenNumUsesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21179,7 +21179,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenNumUses");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenNumUses");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21217,7 +21217,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenTtlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21225,7 +21225,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenTtl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21262,7 +21262,7 @@ namespace Vault.Api
         /// <summary>
         /// Duration in seconds, the lifetime of the token issued by using the SecretID that is generated against this role, before which the token needs to be renewed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role.</param>
         /// <param name="approleRoleTokenTtlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21271,7 +21271,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenTtl");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthApproleRoleRoleNameTokenTtl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21309,7 +21309,7 @@ namespace Vault.Api
         /// <summary>
         /// Trigger the clean-up of expired SecretID entries. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthApproleTidySecretId()
         {
@@ -21345,7 +21345,7 @@ namespace Vault.Api
         /// <summary>
         /// Trigger the clean-up of expired SecretID entries. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAuthApproleTidySecretIdAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -21383,7 +21383,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="awsConfigCertificateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21391,7 +21391,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'certName' is set
             if (certName == null)
-                throw new ApiException(400, "Missing required parameter 'certName' when calling Auth->PostAuthAwsConfigCertificateCertName");
+                throw new VaultApiException(400, "Missing required parameter 'certName' when calling Auth->PostAuthAwsConfigCertificateCertName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21428,7 +21428,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certName">Name of the certificate.</param>
         /// <param name="awsConfigCertificateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21437,7 +21437,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'certName' is set
             if (certName == null)
-                throw new ApiException(400, "Missing required parameter 'certName' when calling Auth->PostAuthAwsConfigCertificateCertName");
+                throw new VaultApiException(400, "Missing required parameter 'certName' when calling Auth->PostAuthAwsConfigCertificateCertName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21475,7 +21475,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigClientRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsConfigClient(AwsConfigClientRequest awsConfigClientRequest = default(AwsConfigClientRequest))
@@ -21514,7 +21514,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigClientRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21555,7 +21555,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigIdentityRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsConfigIdentity(AwsConfigIdentityRequest awsConfigIdentityRequest = default(AwsConfigIdentityRequest))
@@ -21594,7 +21594,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigIdentityRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21635,7 +21635,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsConfigRotateRoot()
         {
@@ -21671,7 +21671,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAuthAwsConfigRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -21709,7 +21709,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="awsConfigStsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21717,7 +21717,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'accountId' is set
             if (accountId == null)
-                throw new ApiException(400, "Missing required parameter 'accountId' when calling Auth->PostAuthAwsConfigStsAccountId");
+                throw new VaultApiException(400, "Missing required parameter 'accountId' when calling Auth->PostAuthAwsConfigStsAccountId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21754,7 +21754,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="accountId">AWS account ID to be associated with STS role. If set, Vault will use assumed credentials to verify any login attempts from EC2 instances in this account.</param>
         /// <param name="awsConfigStsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21763,7 +21763,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'accountId' is set
             if (accountId == null)
-                throw new ApiException(400, "Missing required parameter 'accountId' when calling Auth->PostAuthAwsConfigStsAccountId");
+                throw new VaultApiException(400, "Missing required parameter 'accountId' when calling Auth->PostAuthAwsConfigStsAccountId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21801,7 +21801,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityAccesslistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsConfigTidyIdentityAccesslist(AwsConfigTidyIdentityAccesslistRequest awsConfigTidyIdentityAccesslistRequest = default(AwsConfigTidyIdentityAccesslistRequest))
@@ -21840,7 +21840,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityAccesslistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21881,7 +21881,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityWhitelistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsConfigTidyIdentityWhitelist(AwsConfigTidyIdentityWhitelistRequest awsConfigTidyIdentityWhitelistRequest = default(AwsConfigTidyIdentityWhitelistRequest))
@@ -21920,7 +21920,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyIdentityWhitelistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21961,7 +21961,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagBlacklistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsConfigTidyRoletagBlacklist(AwsConfigTidyRoletagBlacklistRequest awsConfigTidyRoletagBlacklistRequest = default(AwsConfigTidyRoletagBlacklistRequest))
@@ -22000,7 +22000,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagBlacklistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22041,7 +22041,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagDenylistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsConfigTidyRoletagDenylist(AwsConfigTidyRoletagDenylistRequest awsConfigTidyRoletagDenylistRequest = default(AwsConfigTidyRoletagDenylistRequest))
@@ -22080,7 +22080,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigTidyRoletagDenylistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22121,7 +22121,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsLogin(AwsLoginRequest awsLoginRequest = default(AwsLoginRequest))
@@ -22160,7 +22160,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22201,7 +22201,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -22209,7 +22209,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22246,7 +22246,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -22255,7 +22255,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22293,7 +22293,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleTagRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -22301,7 +22301,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRoleTag");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22338,7 +22338,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="awsRoleTagRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -22347,7 +22347,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthAwsRoleRoleTag");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22385,14 +22385,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsRoletagBlacklistRoleTag(string roleTag)
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagBlacklistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagBlacklistRoleTag");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22427,7 +22427,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22435,7 +22435,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagBlacklistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagBlacklistRoleTag");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22471,14 +22471,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsRoletagDenylistRoleTag(string roleTag)
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagDenylistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagDenylistRoleTag");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22513,7 +22513,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleTag">Role tag to be deny listed. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64 encoded.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22521,7 +22521,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleTag' is set
             if (roleTag == null)
-                throw new ApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagDenylistRoleTag");
+                throw new VaultApiException(400, "Missing required parameter 'roleTag' when calling Auth->PostAuthAwsRoletagDenylistRoleTag");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22557,7 +22557,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityAccesslistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsTidyIdentityAccesslist(AwsTidyIdentityAccesslistRequest awsTidyIdentityAccesslistRequest = default(AwsTidyIdentityAccesslistRequest))
@@ -22596,7 +22596,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityAccesslistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22637,7 +22637,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityWhitelistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsTidyIdentityWhitelist(AwsTidyIdentityWhitelistRequest awsTidyIdentityWhitelistRequest = default(AwsTidyIdentityWhitelistRequest))
@@ -22676,7 +22676,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyIdentityWhitelistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22717,7 +22717,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagBlacklistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsTidyRoletagBlacklist(AwsTidyRoletagBlacklistRequest awsTidyRoletagBlacklistRequest = default(AwsTidyRoletagBlacklistRequest))
@@ -22756,7 +22756,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagBlacklistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22797,7 +22797,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagDenylistRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAwsTidyRoletagDenylist(AwsTidyRoletagDenylistRequest awsTidyRoletagDenylistRequest = default(AwsTidyRoletagDenylistRequest))
@@ -22836,7 +22836,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsTidyRoletagDenylistRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22877,7 +22877,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAzureConfig(AzureConfigRequest azureConfigRequest = default(AzureConfigRequest))
@@ -22916,7 +22916,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22957,7 +22957,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthAzureLogin(AzureLoginRequest azureLoginRequest = default(AzureLoginRequest))
@@ -22996,7 +22996,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23037,7 +23037,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23045,7 +23045,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthAzureRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthAzureRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23082,7 +23082,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23091,7 +23091,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthAzureRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthAzureRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23129,7 +23129,7 @@ namespace Vault.Api
         /// <summary>
         /// This path allows you to configure the centrify auth provider to interact with the Centrify Identity Services Platform for authenticating users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthCentrifyConfig(CentrifyConfigRequest centrifyConfigRequest = default(CentrifyConfigRequest))
@@ -23168,7 +23168,7 @@ namespace Vault.Api
         /// <summary>
         /// This path allows you to configure the centrify auth provider to interact with the Centrify Identity Services Platform for authenticating users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23209,7 +23209,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthCentrifyLogin(CentrifyLoginRequest centrifyLoginRequest = default(CentrifyLoginRequest))
@@ -23248,7 +23248,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="centrifyLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23289,7 +23289,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCertsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23297,7 +23297,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCertsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCertsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23334,7 +23334,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage trusted certificates used for authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCertsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23343,7 +23343,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCertsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCertsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23381,7 +23381,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthCertConfig(CertConfigRequest certConfigRequest = default(CertConfigRequest))
@@ -23420,7 +23420,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23461,7 +23461,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage Certificate Revocation Lists checked during authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCrlsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23469,7 +23469,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCrlsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCrlsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23506,7 +23506,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage Certificate Revocation Lists checked during authentication. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the certificate</param>
         /// <param name="certCrlsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23515,7 +23515,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCrlsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthCertCrlsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23553,7 +23553,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthCertLogin(CertLoginRequest certLoginRequest = default(CertLoginRequest))
@@ -23592,7 +23592,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="certLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23633,7 +23633,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthCfConfig(CfConfigRequest cfConfigRequest = default(CfConfigRequest))
@@ -23672,7 +23672,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23713,7 +23713,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthCfLogin(CfLoginRequest cfLoginRequest = default(CfLoginRequest))
@@ -23752,7 +23752,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cfLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23793,7 +23793,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cfRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23801,7 +23801,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthCfRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthCfRolesRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23838,7 +23838,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The name of the role.</param>
         /// <param name="cfRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23847,7 +23847,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthCfRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthCfRolesRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23885,7 +23885,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure credentials used to query the GCP IAM API to verify authenticating service accounts 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthGcpConfig(GcpConfigRequest gcpConfigRequest = default(GcpConfigRequest))
@@ -23924,7 +23924,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure credentials used to query the GCP IAM API to verify authenticating service accounts 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23965,7 +23965,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthGcpLogin(GcpLoginRequest gcpLoginRequest = default(GcpLoginRequest))
@@ -24004,7 +24004,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24045,7 +24045,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a GCP role with associated policies and required attributes. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24053,7 +24053,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24090,7 +24090,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a GCP role with associated policies and required attributes. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24099,7 +24099,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24137,7 +24137,7 @@ namespace Vault.Api
         /// <summary>
         /// Add or remove labels for an existing &#39;gce&#39; role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleLabelsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24145,7 +24145,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameLabels");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameLabels");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24182,7 +24182,7 @@ namespace Vault.Api
         /// <summary>
         /// Add or remove labels for an existing &#39;gce&#39; role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleLabelsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24191,7 +24191,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameLabels");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameLabels");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24229,7 +24229,7 @@ namespace Vault.Api
         /// <summary>
         /// Add or remove service accounts for an existing &#x60;iam&#x60; role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleServiceAccountsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24237,7 +24237,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameServiceAccounts");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameServiceAccounts");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24274,7 +24274,7 @@ namespace Vault.Api
         /// <summary>
         /// Add or remove service accounts for an existing &#x60;iam&#x60; role 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="gcpRoleServiceAccountsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24283,7 +24283,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameServiceAccounts");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthGcpRoleNameServiceAccounts");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24321,7 +24321,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthGithubConfig(GithubConfigRequest githubConfigRequest = default(GithubConfigRequest))
@@ -24360,7 +24360,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24401,7 +24401,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthGithubLogin(GithubLoginRequest githubLoginRequest = default(GithubLoginRequest))
@@ -24440,7 +24440,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="githubLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24481,7 +24481,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single teams mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="githubMapTeamsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24489,7 +24489,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapTeamsKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapTeamsKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24526,7 +24526,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single teams mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the teams mapping</param>
         /// <param name="githubMapTeamsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24535,7 +24535,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapTeamsKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapTeamsKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24573,7 +24573,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single users mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="githubMapUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24581,7 +24581,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapUsersKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapUsersKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24618,7 +24618,7 @@ namespace Vault.Api
         /// <summary>
         /// Read/write/delete a single users mapping 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Key for the users mapping</param>
         /// <param name="githubMapUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24627,7 +24627,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapUsersKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Auth->PostAuthGithubMapUsersKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24665,7 +24665,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the JWT authentication backend. The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthJwtConfig(JwtConfigRequest jwtConfigRequest = default(JwtConfigRequest))
@@ -24704,7 +24704,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the JWT authentication backend. The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24745,7 +24745,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates to Vault using a JWT (or OIDC) token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthJwtLogin(JwtLoginRequest jwtLoginRequest = default(JwtLoginRequest))
@@ -24784,7 +24784,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates to Vault using a JWT (or OIDC) token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24825,7 +24825,7 @@ namespace Vault.Api
         /// <summary>
         /// Request an authorization URL to start an OIDC login flow. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcAuthUrlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthJwtOidcAuthUrl(JwtOidcAuthUrlRequest jwtOidcAuthUrlRequest = default(JwtOidcAuthUrlRequest))
@@ -24864,7 +24864,7 @@ namespace Vault.Api
         /// <summary>
         /// Request an authorization URL to start an OIDC login flow. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcAuthUrlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24905,7 +24905,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to handle form_posts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcCallbackRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthJwtOidcCallback(JwtOidcCallbackRequest jwtOidcCallbackRequest = default(JwtOidcCallbackRequest))
@@ -24944,7 +24944,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to handle form_posts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="jwtOidcCallbackRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24985,7 +24985,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="jwtRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24993,7 +24993,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthJwtRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthJwtRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25030,7 +25030,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="jwtRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25039,7 +25039,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthJwtRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthJwtRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25077,7 +25077,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthKerberosConfig(KerberosConfigRequest kerberosConfigRequest = default(KerberosConfigRequest))
@@ -25116,7 +25116,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25157,7 +25157,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigLdapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthKerberosConfigLdap(KerberosConfigLdapRequest kerberosConfigLdapRequest = default(KerberosConfigLdapRequest))
@@ -25196,7 +25196,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosConfigLdapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25237,7 +25237,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="kerberosGroupsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -25245,7 +25245,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKerberosGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKerberosGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25282,7 +25282,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="kerberosGroupsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25291,7 +25291,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKerberosGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKerberosGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25329,7 +25329,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthKerberosLogin(KerberosLoginRequest kerberosLoginRequest = default(KerberosLoginRequest))
@@ -25368,7 +25368,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kerberosLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25409,7 +25409,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures the JWT Public Key and Kubernetes API information. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthKubernetesConfig(KubernetesConfigRequest kubernetesConfigRequest = default(KubernetesConfigRequest))
@@ -25448,7 +25448,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures the JWT Public Key and Kubernetes API information. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25489,7 +25489,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates Kubernetes service accounts with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthKubernetesLogin(KubernetesLoginRequest kubernetesLoginRequest = default(KubernetesLoginRequest))
@@ -25528,7 +25528,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates Kubernetes service accounts with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25569,7 +25569,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="kubernetesRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -25577,7 +25577,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKubernetesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKubernetesRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25614,7 +25614,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="kubernetesRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25623,7 +25623,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKubernetesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthKubernetesRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25661,7 +25661,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the LDAP server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ldapConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthLdapConfig(LdapConfigRequest ldapConfigRequest = default(LdapConfigRequest))
@@ -25700,7 +25700,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the LDAP server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ldapConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25741,7 +25741,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="ldapGroupsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -25749,7 +25749,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25786,7 +25786,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP group.</param>
         /// <param name="ldapGroupsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25795,7 +25795,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25833,7 +25833,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">DN (distinguished name) to be used for login.</param>
         /// <param name="ldapLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -25841,7 +25841,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthLdapLoginUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthLdapLoginUsername");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25878,7 +25878,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">DN (distinguished name) to be used for login.</param>
         /// <param name="ldapLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25887,7 +25887,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthLdapLoginUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthLdapLoginUsername");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25925,7 +25925,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="ldapUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -25933,7 +25933,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25970,7 +25970,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the LDAP user.</param>
         /// <param name="ldapUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25979,7 +25979,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthLdapUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26017,7 +26017,7 @@ namespace Vault.Api
         /// <summary>
         /// Manages the configuration for the Vault Auth Plugin. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ociConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthOciConfig(OciConfigRequest ociConfigRequest = default(OciConfigRequest))
@@ -26056,7 +26056,7 @@ namespace Vault.Api
         /// <summary>
         /// Manages the configuration for the Vault Auth Plugin. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="ociConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26097,7 +26097,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates to Vault using OCI credentials 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26105,7 +26105,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciLoginRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciLoginRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26142,7 +26142,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates to Vault using OCI credentials 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26151,7 +26151,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciLoginRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciLoginRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26189,7 +26189,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26197,7 +26197,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciRoleRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26234,7 +26234,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a role and associate policies to it. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="ociRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26243,7 +26243,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciRoleRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Auth->PostAuthOciRoleRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26281,7 +26281,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the JWT authentication backend. The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthOidcConfig(OidcConfigRequest oidcConfigRequest = default(OidcConfigRequest))
@@ -26320,7 +26320,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the JWT authentication backend. The JWT authentication backend validates JWTs (or OIDC) using the configured credentials. If using OIDC Discovery, the URL must be provided, along with (optionally) the CA cert to use for the connection. If performing JWT validation locally, a set of public keys must be provided.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26361,7 +26361,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates to Vault using a JWT (or OIDC) token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthOidcLogin(OidcLoginRequest oidcLoginRequest = default(OidcLoginRequest))
@@ -26400,7 +26400,7 @@ namespace Vault.Api
         /// <summary>
         /// Authenticates to Vault using a JWT (or OIDC) token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26441,7 +26441,7 @@ namespace Vault.Api
         /// <summary>
         /// Request an authorization URL to start an OIDC login flow. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcAuthUrlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthOidcOidcAuthUrl(OidcOidcAuthUrlRequest oidcOidcAuthUrlRequest = default(OidcOidcAuthUrlRequest))
@@ -26480,7 +26480,7 @@ namespace Vault.Api
         /// <summary>
         /// Request an authorization URL to start an OIDC login flow. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcAuthUrlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26521,7 +26521,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to handle form_posts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcCallbackRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthOidcOidcCallback(OidcOidcCallbackRequest oidcOidcCallbackRequest = default(OidcOidcCallbackRequest))
@@ -26560,7 +26560,7 @@ namespace Vault.Api
         /// <summary>
         /// Callback endpoint to handle form_posts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oidcOidcCallbackRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26601,7 +26601,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="oidcRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26609,7 +26609,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOidcRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26646,7 +26646,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an role with the backend. A role is required to authenticate with this backend. The role binds   JWT token information with token policies and settings.   The bindings, token polices and token settings can all be configured   using this endpoint
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="oidcRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26655,7 +26655,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOidcRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26693,7 +26693,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint allows you to configure the Okta and its configuration options.  The Okta organization are the characters at the front of the URL for Okta. Example https://ORG.okta.com 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oktaConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthOktaConfig(OktaConfigRequest oktaConfigRequest = default(OktaConfigRequest))
@@ -26732,7 +26732,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint allows you to configure the Okta and its configuration options.  The Okta organization are the characters at the front of the URL for Okta. Example https://ORG.okta.com 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="oktaConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26773,7 +26773,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="oktaGroupsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26781,7 +26781,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaGroupsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26818,7 +26818,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Okta group.</param>
         /// <param name="oktaGroupsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26827,7 +26827,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaGroupsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaGroupsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26865,7 +26865,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username to be used for login.</param>
         /// <param name="oktaLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26873,7 +26873,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthOktaLoginUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthOktaLoginUsername");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26910,7 +26910,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username to be used for login.</param>
         /// <param name="oktaLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26919,7 +26919,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthOktaLoginUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthOktaLoginUsername");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26957,7 +26957,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="oktaUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26965,7 +26965,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27002,7 +27002,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage additional groups for users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the user.</param>
         /// <param name="oktaUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27011,7 +27011,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthOktaUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27049,7 +27049,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the RADIUS server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthRadiusConfig(RadiusConfigRequest radiusConfigRequest = default(RadiusConfigRequest))
@@ -27088,7 +27088,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the RADIUS server to connect to, along with its options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27129,7 +27129,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthRadiusLogin(RadiusLoginRequest radiusLoginRequest = default(RadiusLoginRequest))
@@ -27168,7 +27168,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27209,7 +27209,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlusername">Username to be used for login. (URL parameter)</param>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -27217,7 +27217,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlusername' is set
             if (urlusername == null)
-                throw new ApiException(400, "Missing required parameter 'urlusername' when calling Auth->PostAuthRadiusLoginUrlusername");
+                throw new VaultApiException(400, "Missing required parameter 'urlusername' when calling Auth->PostAuthRadiusLoginUrlusername");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27254,7 +27254,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlusername">Username to be used for login. (URL parameter)</param>
         /// <param name="radiusLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27263,7 +27263,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlusername' is set
             if (urlusername == null)
-                throw new ApiException(400, "Missing required parameter 'urlusername' when calling Auth->PostAuthRadiusLoginUrlusername");
+                throw new VaultApiException(400, "Missing required parameter 'urlusername' when calling Auth->PostAuthRadiusLoginUrlusername");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27301,7 +27301,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="radiusUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -27309,7 +27309,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthRadiusUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthRadiusUsersName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27346,7 +27346,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the RADIUS user.</param>
         /// <param name="radiusUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27355,7 +27355,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthRadiusUsersName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Auth->PostAuthRadiusUsersName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27393,7 +27393,7 @@ namespace Vault.Api
         /// <summary>
         /// The token create path is used to create new tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenCreate()
         {
@@ -27429,7 +27429,7 @@ namespace Vault.Api
         /// <summary>
         /// The token create path is used to create new tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAuthTokenCreateAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -27467,7 +27467,7 @@ namespace Vault.Api
         /// <summary>
         /// The token create path is used to create new orphan tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenCreateOrphan()
         {
@@ -27503,7 +27503,7 @@ namespace Vault.Api
         /// <summary>
         /// The token create path is used to create new orphan tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAuthTokenCreateOrphanAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -27541,14 +27541,14 @@ namespace Vault.Api
         /// <summary>
         /// This token create path is used to create new tokens adhering to the given role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenCreateRoleName(string roleName)
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenCreateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenCreateRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27583,7 +27583,7 @@ namespace Vault.Api
         /// <summary>
         /// This token create path is used to create new tokens adhering to the given role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27591,7 +27591,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenCreateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenCreateRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27627,7 +27627,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenLookup(TokenLookupRequest tokenLookupRequest = default(TokenLookupRequest))
@@ -27666,7 +27666,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27707,7 +27707,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token associated with the given accessor and its properties. Response will not contain the token ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenLookupAccessor(TokenLookupAccessorRequest tokenLookupAccessorRequest = default(TokenLookupAccessorRequest))
@@ -27746,7 +27746,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token associated with the given accessor and its properties. Response will not contain the token ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27787,7 +27787,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupSelfRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenLookupSelf(TokenLookupSelfRequest tokenLookupSelfRequest = default(TokenLookupSelfRequest))
@@ -27826,7 +27826,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will lookup a token and its properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenLookupSelfRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27867,7 +27867,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will renew the given token and prevent expiration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenRenew(TokenRenewRequest tokenRenewRequest = default(TokenRenewRequest))
@@ -27906,7 +27906,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will renew the given token and prevent expiration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27947,7 +27947,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will renew a token associated with the given accessor and its properties. Response will not contain the token ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenRenewAccessor(TokenRenewAccessorRequest tokenRenewAccessorRequest = default(TokenRenewAccessorRequest))
@@ -27986,7 +27986,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will renew a token associated with the given accessor and its properties. Response will not contain the token ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28027,7 +28027,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will renew the token used to call it and prevent expiration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewSelfRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenRenewSelf(TokenRenewSelfRequest tokenRenewSelfRequest = default(TokenRenewSelfRequest))
@@ -28066,7 +28066,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will renew the token used to call it and prevent expiration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRenewSelfRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28107,7 +28107,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the given token and all of its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenRevoke(TokenRevokeRequest tokenRevokeRequest = default(TokenRevokeRequest))
@@ -28146,7 +28146,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the given token and all of its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28187,7 +28187,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the token associated with the accessor and all of its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenRevokeAccessor(TokenRevokeAccessorRequest tokenRevokeAccessorRequest = default(TokenRevokeAccessorRequest))
@@ -28226,7 +28226,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the token associated with the accessor and all of its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28267,7 +28267,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the token and orphan its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeOrphanRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenRevokeOrphan(TokenRevokeOrphanRequest tokenRevokeOrphanRequest = default(TokenRevokeOrphanRequest))
@@ -28306,7 +28306,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the token and orphan its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="tokenRevokeOrphanRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28347,7 +28347,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the token used to call it and all of its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenRevokeSelf()
         {
@@ -28383,7 +28383,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint will delete the token used to call it and all of its child tokens. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAuthTokenRevokeSelfAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -28421,7 +28421,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="tokenRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28429,7 +28429,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenRolesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenRolesRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28466,7 +28466,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleName">Name of the role</param>
         /// <param name="tokenRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28475,7 +28475,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleName' is set
             if (roleName == null)
-                throw new ApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenRolesRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'roleName' when calling Auth->PostAuthTokenRolesRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28513,7 +28513,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint performs cleanup tasks that can be run if certain error conditions have occurred. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAuthTokenTidy()
         {
@@ -28549,7 +28549,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint performs cleanup tasks that can be run if certain error conditions have occurred. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAuthTokenTidyAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -28587,7 +28587,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username of the user.</param>
         /// <param name="userpassLoginRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28595,7 +28595,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassLoginUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassLoginUsername");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28632,7 +28632,7 @@ namespace Vault.Api
         /// <summary>
         /// Log in with a username and password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username of the user.</param>
         /// <param name="userpassLoginRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28641,7 +28641,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassLoginUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassLoginUsername");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28679,7 +28679,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28687,7 +28687,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsername");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28724,7 +28724,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage users allowed to authenticate. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28733,7 +28733,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsername");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsername");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28771,7 +28771,7 @@ namespace Vault.Api
         /// <summary>
         /// Reset user&#39;s password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPasswordRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28779,7 +28779,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePassword");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePassword");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28816,7 +28816,7 @@ namespace Vault.Api
         /// <summary>
         /// Reset user&#39;s password. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPasswordRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28825,7 +28825,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePassword");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePassword");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28863,7 +28863,7 @@ namespace Vault.Api
         /// <summary>
         /// Update the policies associated with the username. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPoliciesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28871,7 +28871,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePolicies");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28908,7 +28908,7 @@ namespace Vault.Api
         /// <summary>
         /// Update the policies associated with the username. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="username">Username for this user.</param>
         /// <param name="userpassUsersPoliciesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28917,7 +28917,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'username' is set
             if (username == null)
-                throw new ApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePolicies");
+                throw new VaultApiException(400, "Missing required parameter 'username' when calling Auth->PostAuthUserpassUsersUsernamePolicies");
 
 
             RequestOptions requestOptions = new RequestOptions();

--- a/src/Vault/Api/Identity.cs
+++ b/src/Vault/Api/Identity.cs
@@ -29,7 +29,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityAliasIdId(string id);
@@ -39,7 +39,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityEntityAliasIdId(string id);
@@ -49,7 +49,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityEntityIdId(string id);
@@ -59,7 +59,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityEntityNameName(string name);
@@ -69,7 +69,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityGroupAliasIdId(string id);
@@ -79,7 +79,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityGroupIdId(string id);
@@ -89,7 +89,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityGroupNameName(string name);
@@ -99,7 +99,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityMfaLoginEnforcementName(string name);
@@ -109,7 +109,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityMfaMethodDuoMethodId(string methodId);
@@ -119,7 +119,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityMfaMethodOktaMethodId(string methodId);
@@ -129,7 +129,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityMfaMethodPingidMethodId(string methodId);
@@ -139,7 +139,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityMfaMethodTotpMethodId(string methodId);
@@ -149,7 +149,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityOidcAssignmentName(string name);
@@ -159,7 +159,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityOidcClientName(string name);
@@ -169,7 +169,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityOidcKeyName(string name);
@@ -179,7 +179,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityOidcProviderName(string name);
@@ -189,7 +189,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityOidcRoleName(string name);
@@ -199,7 +199,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityOidcScopeName(string name);
@@ -209,7 +209,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteIdentityPersonaIdId(string id);
@@ -219,7 +219,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityAliasId(string list);
@@ -229,7 +229,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityAliasIdId(string id);
@@ -239,7 +239,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityEntityAliasId(string list);
@@ -249,7 +249,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityEntityAliasIdId(string id);
@@ -259,7 +259,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityEntityId(string list);
@@ -269,7 +269,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityEntityIdId(string id);
@@ -279,7 +279,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityEntityName(string list);
@@ -289,7 +289,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityEntityNameName(string name);
@@ -299,7 +299,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityGroupAliasId(string list);
@@ -309,7 +309,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityGroupAliasIdId(string id);
@@ -319,7 +319,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityGroupId(string list);
@@ -329,7 +329,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityGroupIdId(string id);
@@ -339,7 +339,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityGroupName(string list);
@@ -349,7 +349,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityGroupNameName(string name);
@@ -359,7 +359,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaLoginEnforcement(string list);
@@ -369,7 +369,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaLoginEnforcementName(string name);
@@ -379,7 +379,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethod(string list);
@@ -389,7 +389,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodDuo(string list);
@@ -399,7 +399,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodDuoMethodId(string methodId);
@@ -409,7 +409,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodMethodId(string methodId);
@@ -419,7 +419,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodOkta(string list);
@@ -429,7 +429,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodOktaMethodId(string methodId);
@@ -439,7 +439,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodPingid(string list);
@@ -449,7 +449,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodPingidMethodId(string methodId);
@@ -459,7 +459,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodTotp(string list);
@@ -469,7 +469,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityMfaMethodTotpMethodId(string methodId);
@@ -479,7 +479,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcAssignment(string list);
@@ -489,7 +489,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcAssignmentName(string name);
@@ -499,7 +499,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcClient(string list);
@@ -509,7 +509,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcClientName(string name);
@@ -519,7 +519,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcConfig();
         /// <summary>
@@ -528,7 +528,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcKey(string list);
@@ -538,7 +538,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcKeyName(string name);
@@ -548,7 +548,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcProvider(string list);
@@ -558,7 +558,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcProviderName(string name);
@@ -568,7 +568,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcProviderNameAuthorize(string name);
@@ -578,7 +578,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcProviderNameUserinfo(string name);
@@ -588,7 +588,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcProviderNameWellKnownKeys(string name);
@@ -598,7 +598,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcProviderNameWellKnownOpenidConfiguration(string name);
@@ -608,7 +608,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcRole(string list);
@@ -618,7 +618,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcRoleName(string name);
@@ -628,7 +628,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcScope(string list);
@@ -638,7 +638,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcScopeName(string name);
@@ -648,7 +648,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcTokenName(string name);
@@ -658,7 +658,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcWellKnownKeys();
         /// <summary>
@@ -667,7 +667,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityOidcWellKnownOpenidConfiguration();
         /// <summary>
@@ -676,7 +676,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityPersonaId(string list);
@@ -686,7 +686,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetIdentityPersonaIdId(string id);
@@ -696,7 +696,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityAliasRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityAlias(IdentityAliasRequest identityAliasRequest = default(IdentityAliasRequest));
@@ -706,7 +706,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityAliasIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -717,7 +717,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityEntity(IdentityEntityRequest identityEntityRequest = default(IdentityEntityRequest));
@@ -727,7 +727,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityAliasRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityEntityAlias(IdentityEntityAliasRequest identityEntityAliasRequest = default(IdentityEntityAliasRequest));
@@ -737,7 +737,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityEntityAliasIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -748,7 +748,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityBatchDeleteRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityEntityBatchDelete(IdentityEntityBatchDeleteRequest identityEntityBatchDeleteRequest = default(IdentityEntityBatchDeleteRequest));
@@ -758,7 +758,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="identityEntityIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -769,7 +769,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityMergeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityEntityMerge(IdentityEntityMergeRequest identityEntityMergeRequest = default(IdentityEntityMergeRequest));
@@ -779,7 +779,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="identityEntityNameRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -790,7 +790,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityGroup(IdentityGroupRequest identityGroupRequest = default(IdentityGroupRequest));
@@ -800,7 +800,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupAliasRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityGroupAlias(IdentityGroupAliasRequest identityGroupAliasRequest = default(IdentityGroupAliasRequest));
@@ -810,7 +810,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="identityGroupAliasIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -821,7 +821,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="identityGroupIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -832,7 +832,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="identityGroupNameRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -843,7 +843,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupEntityRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityLookupEntity(IdentityLookupEntityRequest identityLookupEntityRequest = default(IdentityLookupEntityRequest));
@@ -853,7 +853,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupGroupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityLookupGroup(IdentityLookupGroupRequest identityLookupGroupRequest = default(IdentityLookupGroupRequest));
@@ -863,7 +863,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="identityMfaLoginEnforcementRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -874,7 +874,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodDuoRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -885,7 +885,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodOktaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -896,7 +896,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodPingidRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -907,7 +907,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityMfaMethodTotpAdminDestroy(IdentityMfaMethodTotpAdminDestroyRequest identityMfaMethodTotpAdminDestroyRequest = default(IdentityMfaMethodTotpAdminDestroyRequest));
@@ -917,7 +917,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityMfaMethodTotpAdminGenerate(IdentityMfaMethodTotpAdminGenerateRequest identityMfaMethodTotpAdminGenerateRequest = default(IdentityMfaMethodTotpAdminGenerateRequest));
@@ -927,7 +927,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityMfaMethodTotpGenerate(IdentityMfaMethodTotpGenerateRequest identityMfaMethodTotpGenerateRequest = default(IdentityMfaMethodTotpGenerateRequest));
@@ -937,7 +937,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodTotpRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -948,7 +948,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="identityOidcAssignmentRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -959,7 +959,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="identityOidcClientRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -970,7 +970,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityOidcConfig(IdentityOidcConfigRequest identityOidcConfigRequest = default(IdentityOidcConfigRequest));
@@ -980,7 +980,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcIntrospectRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityOidcIntrospect(IdentityOidcIntrospectRequest identityOidcIntrospectRequest = default(IdentityOidcIntrospectRequest));
@@ -990,7 +990,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1001,7 +1001,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRotateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1012,7 +1012,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1023,7 +1023,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderAuthorizeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1034,7 +1034,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderTokenRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1045,7 +1045,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityOidcProviderNameUserinfo(string name);
@@ -1055,7 +1055,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="identityOidcRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1066,7 +1066,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="identityOidcScopeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1077,7 +1077,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityPersonaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostIdentityPersona(IdentityPersonaRequest identityPersonaRequest = default(IdentityPersonaRequest));
@@ -1087,7 +1087,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="identityPersonaIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1108,7 +1108,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1120,7 +1120,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1132,7 +1132,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1144,7 +1144,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1156,7 +1156,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1168,7 +1168,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1180,7 +1180,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1192,7 +1192,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1204,7 +1204,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1216,7 +1216,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1228,7 +1228,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1240,7 +1240,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1252,7 +1252,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1264,7 +1264,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1276,7 +1276,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1288,7 +1288,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1300,7 +1300,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1312,7 +1312,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1324,7 +1324,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1336,7 +1336,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1348,7 +1348,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1360,7 +1360,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1372,7 +1372,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1384,7 +1384,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1396,7 +1396,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1408,7 +1408,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1420,7 +1420,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1432,7 +1432,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1444,7 +1444,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1456,7 +1456,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1468,7 +1468,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1480,7 +1480,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1492,7 +1492,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1504,7 +1504,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1516,7 +1516,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1528,7 +1528,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1540,7 +1540,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1552,7 +1552,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1564,7 +1564,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1576,7 +1576,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1588,7 +1588,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1600,7 +1600,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1612,7 +1612,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1624,7 +1624,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1636,7 +1636,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1648,7 +1648,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1660,7 +1660,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1672,7 +1672,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1684,7 +1684,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1696,7 +1696,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetIdentityOidcConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1707,7 +1707,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1719,7 +1719,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1731,7 +1731,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1743,7 +1743,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1755,7 +1755,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1767,7 +1767,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1779,7 +1779,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1791,7 +1791,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1803,7 +1803,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1815,7 +1815,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1827,7 +1827,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1839,7 +1839,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1851,7 +1851,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1863,7 +1863,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetIdentityOidcWellKnownKeysAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1874,7 +1874,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetIdentityOidcWellKnownOpenidConfigurationAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1885,7 +1885,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1897,7 +1897,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1909,7 +1909,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityAliasRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1921,7 +1921,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityAliasIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -1934,7 +1934,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1946,7 +1946,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityAliasRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1958,7 +1958,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityEntityAliasIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -1971,7 +1971,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityBatchDeleteRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1983,7 +1983,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="identityEntityIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -1996,7 +1996,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityMergeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2008,7 +2008,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="identityEntityNameRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2021,7 +2021,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2033,7 +2033,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupAliasRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2045,7 +2045,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="identityGroupAliasIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2058,7 +2058,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="identityGroupIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2071,7 +2071,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="identityGroupNameRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2084,7 +2084,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupEntityRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2096,7 +2096,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupGroupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2108,7 +2108,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="identityMfaLoginEnforcementRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2121,7 +2121,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodDuoRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2134,7 +2134,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodOktaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2147,7 +2147,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodPingidRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2160,7 +2160,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2172,7 +2172,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2184,7 +2184,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2196,7 +2196,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodTotpRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2209,7 +2209,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="identityOidcAssignmentRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2222,7 +2222,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="identityOidcClientRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2235,7 +2235,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2247,7 +2247,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcIntrospectRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2259,7 +2259,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2272,7 +2272,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRotateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2285,7 +2285,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2298,7 +2298,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderAuthorizeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2311,7 +2311,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderTokenRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2324,7 +2324,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2336,7 +2336,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="identityOidcRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2349,7 +2349,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="identityOidcScopeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2362,7 +2362,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityPersonaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2374,7 +2374,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="identityPersonaIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2405,7 +2405,7 @@ namespace Vault.Api
             this.Configuration = apiClient.Configuration;
             this.Client = apiClient;
             this.AsynchronousClient = apiClient;
-            this.ExceptionFactory = Vault.Client.Configuration.DefaultExceptionFactory;
+            this.ExceptionFactory = Configuration.DefaultExceptionFactory;
         }
 
         /// <summary>
@@ -2453,14 +2453,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityAliasIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -2495,7 +2495,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2503,7 +2503,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -2539,14 +2539,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityEntityAliasIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -2581,7 +2581,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2589,7 +2589,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -2625,14 +2625,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity ID 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityEntityIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -2667,7 +2667,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity ID 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2675,7 +2675,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityEntityIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -2711,14 +2711,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity name 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityEntityNameName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityEntityNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityEntityNameName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -2753,7 +2753,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity name 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2761,7 +2761,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityEntityNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityEntityNameName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -2797,14 +2797,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityGroupAliasIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -2839,7 +2839,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2847,7 +2847,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -2883,14 +2883,14 @@ namespace Vault.Api
         /// <summary>
         /// Update or delete an existing group using its ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityGroupIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -2925,7 +2925,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or delete an existing group using its ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2933,7 +2933,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityGroupIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -2969,14 +2969,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityGroupNameName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityGroupNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityGroupNameName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3011,7 +3011,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3019,7 +3019,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityGroupNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityGroupNameName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3055,14 +3055,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete a login enforcement 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityMfaLoginEnforcementName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityMfaLoginEnforcementName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityMfaLoginEnforcementName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3097,7 +3097,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete a login enforcement 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3105,7 +3105,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityMfaLoginEnforcementName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityMfaLoginEnforcementName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3141,14 +3141,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityMfaMethodDuoMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodDuoMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodDuoMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3183,7 +3183,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3191,7 +3191,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodDuoMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodDuoMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3227,14 +3227,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityMfaMethodOktaMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodOktaMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodOktaMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3269,7 +3269,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3277,7 +3277,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodOktaMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodOktaMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3313,14 +3313,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityMfaMethodPingidMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodPingidMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodPingidMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3355,7 +3355,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3363,7 +3363,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodPingidMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodPingidMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3399,14 +3399,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityMfaMethodTotpMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodTotpMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodTotpMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3441,7 +3441,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3449,7 +3449,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodTotpMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->DeleteIdentityMfaMethodTotpMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3485,14 +3485,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityOidcAssignmentName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcAssignmentName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcAssignmentName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3527,7 +3527,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3535,7 +3535,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcAssignmentName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcAssignmentName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3571,14 +3571,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityOidcClientName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcClientName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcClientName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3613,7 +3613,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3621,7 +3621,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcClientName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcClientName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3657,14 +3657,14 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations for OIDC keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityOidcKeyName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcKeyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3699,7 +3699,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations for OIDC keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3707,7 +3707,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcKeyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3743,14 +3743,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityOidcProviderName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcProviderName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcProviderName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3785,7 +3785,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3793,7 +3793,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcProviderName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcProviderName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3829,14 +3829,14 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations on OIDC Roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityOidcRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3871,7 +3871,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations on OIDC Roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3879,7 +3879,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3915,14 +3915,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityOidcScopeName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcScopeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcScopeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3957,7 +3957,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3965,7 +3965,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcScopeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->DeleteIdentityOidcScopeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4001,14 +4001,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteIdentityPersonaIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityPersonaIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityPersonaIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4043,7 +4043,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4051,7 +4051,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityPersonaIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->DeleteIdentityPersonaIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4087,14 +4087,14 @@ namespace Vault.Api
         /// <summary>
         /// List all the alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityAliasId(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityAliasId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityAliasId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4129,7 +4129,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4137,7 +4137,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityAliasId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityAliasId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4173,14 +4173,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityAliasIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4215,7 +4215,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4223,7 +4223,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4259,14 +4259,14 @@ namespace Vault.Api
         /// <summary>
         /// List all the alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityEntityAliasId(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityAliasId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityAliasId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4301,7 +4301,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4309,7 +4309,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityAliasId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityAliasId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4345,14 +4345,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityEntityAliasIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4387,7 +4387,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4395,7 +4395,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4431,14 +4431,14 @@ namespace Vault.Api
         /// <summary>
         /// List all the entity IDs 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityEntityId(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4473,7 +4473,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the entity IDs 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4481,7 +4481,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4517,14 +4517,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity ID 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityEntityIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4559,7 +4559,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity ID 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4567,7 +4567,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityEntityIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4603,14 +4603,14 @@ namespace Vault.Api
         /// <summary>
         /// List all the entity names 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityEntityName(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityName");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4645,7 +4645,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the entity names 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4653,7 +4653,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityName");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityEntityName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4689,14 +4689,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity name 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityEntityNameName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityEntityNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityEntityNameName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4731,7 +4731,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity name 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4739,7 +4739,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityEntityNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityEntityNameName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4775,14 +4775,14 @@ namespace Vault.Api
         /// <summary>
         /// List all the group alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityGroupAliasId(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupAliasId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupAliasId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4817,7 +4817,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the group alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4825,7 +4825,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupAliasId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupAliasId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4861,14 +4861,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityGroupAliasIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4903,7 +4903,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4911,7 +4911,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4947,14 +4947,14 @@ namespace Vault.Api
         /// <summary>
         /// List all the group IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityGroupId(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4989,7 +4989,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the group IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4997,7 +4997,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5033,14 +5033,14 @@ namespace Vault.Api
         /// <summary>
         /// Update or delete an existing group using its ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityGroupIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5075,7 +5075,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or delete an existing group using its ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5083,7 +5083,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityGroupIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5119,14 +5119,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityGroupName(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupName");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5161,7 +5161,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5169,7 +5169,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupName");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityGroupName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5205,14 +5205,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityGroupNameName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityGroupNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityGroupNameName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5247,7 +5247,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5255,7 +5255,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityGroupNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityGroupNameName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5291,14 +5291,14 @@ namespace Vault.Api
         /// <summary>
         /// List login enforcements 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaLoginEnforcement(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaLoginEnforcement");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaLoginEnforcement");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5333,7 +5333,7 @@ namespace Vault.Api
         /// <summary>
         /// List login enforcements 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5341,7 +5341,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaLoginEnforcement");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaLoginEnforcement");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5377,14 +5377,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the current login enforcement 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaLoginEnforcementName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityMfaLoginEnforcementName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityMfaLoginEnforcementName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5419,7 +5419,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current login enforcement 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5427,7 +5427,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityMfaLoginEnforcementName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityMfaLoginEnforcementName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5463,14 +5463,14 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for all MFA methods 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethod(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethod");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethod");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5505,7 +5505,7 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for all MFA methods 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5513,7 +5513,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethod");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethod");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5549,14 +5549,14 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodDuo(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodDuo");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodDuo");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5591,7 +5591,7 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5599,7 +5599,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodDuo");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodDuo");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5635,14 +5635,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodDuoMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodDuoMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodDuoMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5677,7 +5677,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5685,7 +5685,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodDuoMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodDuoMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5721,14 +5721,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given ID regardless of the MFA method type 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5763,7 +5763,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given ID regardless of the MFA method type 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5771,7 +5771,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5807,14 +5807,14 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodOkta(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodOkta");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodOkta");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5849,7 +5849,7 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5857,7 +5857,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodOkta");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodOkta");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5893,14 +5893,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodOktaMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodOktaMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodOktaMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5935,7 +5935,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5943,7 +5943,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodOktaMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodOktaMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5979,14 +5979,14 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodPingid(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodPingid");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodPingid");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6021,7 +6021,7 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6029,7 +6029,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodPingid");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodPingid");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6065,14 +6065,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodPingidMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodPingidMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodPingidMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6107,7 +6107,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6115,7 +6115,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodPingidMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodPingidMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6151,14 +6151,14 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodTotp(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodTotp");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodTotp");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6193,7 +6193,7 @@ namespace Vault.Api
         /// <summary>
         /// List MFA method configurations for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6201,7 +6201,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodTotp");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityMfaMethodTotp");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6237,14 +6237,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityMfaMethodTotpMethodId(string methodId)
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodTotpMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodTotpMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6279,7 +6279,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the current configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6287,7 +6287,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodTotpMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->GetIdentityMfaMethodTotpMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6323,14 +6323,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcAssignment(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcAssignment");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcAssignment");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6365,7 +6365,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6373,7 +6373,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcAssignment");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcAssignment");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6409,14 +6409,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcAssignmentName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcAssignmentName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcAssignmentName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6451,7 +6451,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6459,7 +6459,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcAssignmentName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcAssignmentName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6495,14 +6495,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcClient(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcClient");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcClient");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6537,7 +6537,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6545,7 +6545,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcClient");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcClient");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6581,14 +6581,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcClientName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcClientName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcClientName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6623,7 +6623,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6631,7 +6631,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcClientName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcClientName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6667,7 +6667,7 @@ namespace Vault.Api
         /// <summary>
         /// OIDC configuration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcConfig()
         {
@@ -6703,7 +6703,7 @@ namespace Vault.Api
         /// <summary>
         /// OIDC configuration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetIdentityOidcConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6741,14 +6741,14 @@ namespace Vault.Api
         /// <summary>
         /// List OIDC keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcKey(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcKey");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6783,7 +6783,7 @@ namespace Vault.Api
         /// <summary>
         /// List OIDC keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6791,7 +6791,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcKey");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6827,14 +6827,14 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations for OIDC keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcKeyName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcKeyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6869,7 +6869,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations for OIDC keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6877,7 +6877,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcKeyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6913,14 +6913,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcProvider(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcProvider");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcProvider");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6955,7 +6955,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6963,7 +6963,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcProvider");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcProvider");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6999,14 +6999,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcProviderName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7041,7 +7041,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7049,7 +7049,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7085,14 +7085,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcProviderNameAuthorize(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameAuthorize");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameAuthorize");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7127,7 +7127,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7135,7 +7135,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameAuthorize");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameAuthorize");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7171,14 +7171,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcProviderNameUserinfo(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameUserinfo");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameUserinfo");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7213,7 +7213,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7221,7 +7221,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameUserinfo");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameUserinfo");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7257,14 +7257,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcProviderNameWellKnownKeys(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownKeys");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownKeys");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7299,7 +7299,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7307,7 +7307,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownKeys");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownKeys");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7343,14 +7343,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcProviderNameWellKnownOpenidConfiguration(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownOpenidConfiguration");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownOpenidConfiguration");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7385,7 +7385,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7393,7 +7393,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownOpenidConfiguration");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcProviderNameWellKnownOpenidConfiguration");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7429,14 +7429,14 @@ namespace Vault.Api
         /// <summary>
         /// List configured OIDC roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7471,7 +7471,7 @@ namespace Vault.Api
         /// <summary>
         /// List configured OIDC roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7479,7 +7479,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7515,14 +7515,14 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations on OIDC Roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7557,7 +7557,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations on OIDC Roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7565,7 +7565,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7601,14 +7601,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcScope(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcScope");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcScope");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7643,7 +7643,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7651,7 +7651,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcScope");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityOidcScope");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7687,14 +7687,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcScopeName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcScopeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcScopeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7729,7 +7729,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7737,7 +7737,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcScopeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcScopeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7773,14 +7773,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate an OIDC token 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcTokenName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcTokenName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcTokenName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7815,7 +7815,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an OIDC token 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7823,7 +7823,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcTokenName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->GetIdentityOidcTokenName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7859,7 +7859,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve public keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcWellKnownKeys()
         {
@@ -7895,7 +7895,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve public keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetIdentityOidcWellKnownKeysAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7933,7 +7933,7 @@ namespace Vault.Api
         /// <summary>
         /// Query OIDC configurations 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityOidcWellKnownOpenidConfiguration()
         {
@@ -7969,7 +7969,7 @@ namespace Vault.Api
         /// <summary>
         /// Query OIDC configurations 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetIdentityOidcWellKnownOpenidConfigurationAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8007,14 +8007,14 @@ namespace Vault.Api
         /// <summary>
         /// List all the alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityPersonaId(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityPersonaId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityPersonaId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8049,7 +8049,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the alias IDs. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8057,7 +8057,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityPersonaId");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Identity->GetIdentityPersonaId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8093,14 +8093,14 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetIdentityPersonaIdId(string id)
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityPersonaIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityPersonaIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8135,7 +8135,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8143,7 +8143,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityPersonaIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->GetIdentityPersonaIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8179,7 +8179,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new alias. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityAliasRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityAlias(IdentityAliasRequest identityAliasRequest = default(IdentityAliasRequest))
@@ -8218,7 +8218,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new alias. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityAliasRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8259,7 +8259,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityAliasIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -8267,7 +8267,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8304,7 +8304,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityAliasIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -8313,7 +8313,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8351,7 +8351,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new entity 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityEntity(IdentityEntityRequest identityEntityRequest = default(IdentityEntityRequest))
@@ -8390,7 +8390,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new entity 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8431,7 +8431,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new alias. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityAliasRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityEntityAlias(IdentityEntityAliasRequest identityEntityAliasRequest = default(IdentityEntityAliasRequest))
@@ -8470,7 +8470,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new alias. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityAliasRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8511,7 +8511,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityEntityAliasIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -8519,7 +8519,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8556,7 +8556,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the alias</param>
         /// <param name="identityEntityAliasIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -8565,7 +8565,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8603,7 +8603,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete all of the entities provided 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityBatchDeleteRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityEntityBatchDelete(IdentityEntityBatchDeleteRequest identityEntityBatchDeleteRequest = default(IdentityEntityBatchDeleteRequest))
@@ -8642,7 +8642,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete all of the entities provided 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityBatchDeleteRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8683,7 +8683,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity ID 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="identityEntityIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -8691,7 +8691,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8728,7 +8728,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity ID 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the entity. If set, updates the corresponding existing entity.</param>
         /// <param name="identityEntityIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -8737,7 +8737,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityEntityIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8775,7 +8775,7 @@ namespace Vault.Api
         /// <summary>
         /// Merge two or more entities together 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityMergeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityEntityMerge(IdentityEntityMergeRequest identityEntityMergeRequest = default(IdentityEntityMergeRequest))
@@ -8814,7 +8814,7 @@ namespace Vault.Api
         /// <summary>
         /// Merge two or more entities together 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityEntityMergeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8855,7 +8855,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity name 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="identityEntityNameRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -8863,7 +8863,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityEntityNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityEntityNameName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8900,7 +8900,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an entity using entity name 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the entity</param>
         /// <param name="identityEntityNameRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -8909,7 +8909,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityEntityNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityEntityNameName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8947,7 +8947,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new group. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityGroup(IdentityGroupRequest identityGroupRequest = default(IdentityGroupRequest))
@@ -8986,7 +8986,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new group. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9027,7 +9027,7 @@ namespace Vault.Api
         /// <summary>
         /// Creates a new group alias, or updates an existing one. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupAliasRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityGroupAlias(IdentityGroupAliasRequest identityGroupAliasRequest = default(IdentityGroupAliasRequest))
@@ -9066,7 +9066,7 @@ namespace Vault.Api
         /// <summary>
         /// Creates a new group alias, or updates an existing one. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityGroupAliasRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9107,7 +9107,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="identityGroupAliasIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -9115,7 +9115,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupAliasIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9152,7 +9152,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group alias.</param>
         /// <param name="identityGroupAliasIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -9161,7 +9161,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupAliasIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupAliasIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9199,7 +9199,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or delete an existing group using its ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="identityGroupIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -9207,7 +9207,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9244,7 +9244,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or delete an existing group using its ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the group. If set, updates the corresponding existing group.</param>
         /// <param name="identityGroupIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -9253,7 +9253,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityGroupIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9291,7 +9291,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="identityGroupNameRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -9299,7 +9299,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityGroupNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityGroupNameName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9336,7 +9336,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the group.</param>
         /// <param name="identityGroupNameRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -9345,7 +9345,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityGroupNameName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityGroupNameName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9383,7 +9383,7 @@ namespace Vault.Api
         /// <summary>
         /// Query entities based on various properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupEntityRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityLookupEntity(IdentityLookupEntityRequest identityLookupEntityRequest = default(IdentityLookupEntityRequest))
@@ -9422,7 +9422,7 @@ namespace Vault.Api
         /// <summary>
         /// Query entities based on various properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupEntityRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9463,7 +9463,7 @@ namespace Vault.Api
         /// <summary>
         /// Query groups based on various properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupGroupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityLookupGroup(IdentityLookupGroupRequest identityLookupGroupRequest = default(IdentityLookupGroupRequest))
@@ -9502,7 +9502,7 @@ namespace Vault.Api
         /// <summary>
         /// Query groups based on various properties. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityLookupGroupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9543,7 +9543,7 @@ namespace Vault.Api
         /// <summary>
         /// Create or update a login enforcement 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="identityMfaLoginEnforcementRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -9551,7 +9551,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityMfaLoginEnforcementName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityMfaLoginEnforcementName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9588,7 +9588,7 @@ namespace Vault.Api
         /// <summary>
         /// Create or update a login enforcement 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name for this login enforcement configuration</param>
         /// <param name="identityMfaLoginEnforcementRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -9597,7 +9597,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityMfaLoginEnforcementName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityMfaLoginEnforcementName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9635,7 +9635,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodDuoRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -9643,7 +9643,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodDuoMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodDuoMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9680,7 +9680,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodDuoRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -9689,7 +9689,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodDuoMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodDuoMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9727,7 +9727,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodOktaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -9735,7 +9735,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodOktaMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodOktaMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9772,7 +9772,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodOktaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -9781,7 +9781,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodOktaMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodOktaMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9819,7 +9819,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodPingidRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -9827,7 +9827,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodPingidMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodPingidMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9864,7 +9864,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodPingidRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -9873,7 +9873,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodPingidMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodPingidMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9911,7 +9911,7 @@ namespace Vault.Api
         /// <summary>
         /// Destroys a TOTP secret for the given MFA method ID on the given entity 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityMfaMethodTotpAdminDestroy(IdentityMfaMethodTotpAdminDestroyRequest identityMfaMethodTotpAdminDestroyRequest = default(IdentityMfaMethodTotpAdminDestroyRequest))
@@ -9950,7 +9950,7 @@ namespace Vault.Api
         /// <summary>
         /// Destroys a TOTP secret for the given MFA method ID on the given entity 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9991,7 +9991,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create TOTP secret for the given method ID on the given entity. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityMfaMethodTotpAdminGenerate(IdentityMfaMethodTotpAdminGenerateRequest identityMfaMethodTotpAdminGenerateRequest = default(IdentityMfaMethodTotpAdminGenerateRequest))
@@ -10030,7 +10030,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create TOTP secret for the given method ID on the given entity. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpAdminGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10071,7 +10071,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create TOTP secret for the given method ID on the given entity. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityMfaMethodTotpGenerate(IdentityMfaMethodTotpGenerateRequest identityMfaMethodTotpGenerateRequest = default(IdentityMfaMethodTotpGenerateRequest))
@@ -10110,7 +10110,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create TOTP secret for the given method ID on the given entity. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityMfaMethodTotpGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10151,7 +10151,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodTotpRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10159,7 +10159,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodTotpMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodTotpMethodId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10196,7 +10196,7 @@ namespace Vault.Api
         /// <summary>
         /// Update or create a configuration for the given MFA method 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="methodId">The unique identifier for this MFA method.</param>
         /// <param name="identityMfaMethodTotpRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10205,7 +10205,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'methodId' is set
             if (methodId == null)
-                throw new ApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodTotpMethodId");
+                throw new VaultApiException(400, "Missing required parameter 'methodId' when calling Identity->PostIdentityMfaMethodTotpMethodId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10243,7 +10243,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="identityOidcAssignmentRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10251,7 +10251,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcAssignmentName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcAssignmentName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10288,7 +10288,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the assignment</param>
         /// <param name="identityOidcAssignmentRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10297,7 +10297,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcAssignmentName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcAssignmentName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10335,7 +10335,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="identityOidcClientRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10343,7 +10343,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcClientName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcClientName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10380,7 +10380,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the client.</param>
         /// <param name="identityOidcClientRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10389,7 +10389,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcClientName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcClientName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10427,7 +10427,7 @@ namespace Vault.Api
         /// <summary>
         /// OIDC configuration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityOidcConfig(IdentityOidcConfigRequest identityOidcConfigRequest = default(IdentityOidcConfigRequest))
@@ -10466,7 +10466,7 @@ namespace Vault.Api
         /// <summary>
         /// OIDC configuration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10507,7 +10507,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify the authenticity of an OIDC token 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcIntrospectRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityOidcIntrospect(IdentityOidcIntrospectRequest identityOidcIntrospectRequest = default(IdentityOidcIntrospectRequest))
@@ -10546,7 +10546,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify the authenticity of an OIDC token 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityOidcIntrospectRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10587,7 +10587,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations for OIDC keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10595,7 +10595,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10632,7 +10632,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations for OIDC keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10641,7 +10641,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10679,7 +10679,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotate a named OIDC key. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRotateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10687,7 +10687,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyNameRotate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyNameRotate");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10724,7 +10724,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotate a named OIDC key. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="identityOidcKeyRotateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10733,7 +10733,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyNameRotate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcKeyNameRotate");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10771,7 +10771,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10779,7 +10779,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10816,7 +10816,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10825,7 +10825,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10863,7 +10863,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderAuthorizeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10871,7 +10871,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameAuthorize");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameAuthorize");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10908,7 +10908,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderAuthorizeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10917,7 +10917,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameAuthorize");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameAuthorize");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10955,7 +10955,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderTokenRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10963,7 +10963,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameToken");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameToken");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11000,7 +11000,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="identityOidcProviderTokenRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11009,7 +11009,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameToken");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameToken");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11047,14 +11047,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityOidcProviderNameUserinfo(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameUserinfo");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameUserinfo");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11089,7 +11089,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the provider</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11097,7 +11097,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameUserinfo");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcProviderNameUserinfo");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11133,7 +11133,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations on OIDC Roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="identityOidcRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11141,7 +11141,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11178,7 +11178,7 @@ namespace Vault.Api
         /// <summary>
         /// CRUD operations on OIDC Roles 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="identityOidcRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11187,7 +11187,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11225,7 +11225,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="identityOidcScopeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11233,7 +11233,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcScopeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcScopeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11270,7 +11270,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the scope</param>
         /// <param name="identityOidcScopeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11279,7 +11279,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcScopeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Identity->PostIdentityOidcScopeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11317,7 +11317,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new alias. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityPersonaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostIdentityPersona(IdentityPersonaRequest identityPersonaRequest = default(IdentityPersonaRequest))
@@ -11356,7 +11356,7 @@ namespace Vault.Api
         /// <summary>
         /// Create a new alias. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="identityPersonaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11397,7 +11397,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="identityPersonaIdRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11405,7 +11405,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityPersonaIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityPersonaIdId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11442,7 +11442,7 @@ namespace Vault.Api
         /// <summary>
         /// Update, read or delete an alias ID. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="id">ID of the persona</param>
         /// <param name="identityPersonaIdRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11451,7 +11451,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'id' is set
             if (id == null)
-                throw new ApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityPersonaIdId");
+                throw new VaultApiException(400, "Missing required parameter 'id' when calling Identity->PostIdentityPersonaIdId");
 
 
             RequestOptions requestOptions = new RequestOptions();

--- a/src/Vault/Api/Secrets.cs
+++ b/src/Vault/Api/Secrets.cs
@@ -29,7 +29,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAdConfig();
         /// <summary>
@@ -38,7 +38,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAdLibraryName(string name);
@@ -48,7 +48,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAdRolesName(string name);
@@ -58,7 +58,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAlicloudConfig();
         /// <summary>
@@ -67,7 +67,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAlicloudRoleName(string name);
@@ -77,7 +77,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAwsRolesName(string name);
@@ -87,7 +87,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAzureConfig();
         /// <summary>
@@ -96,7 +96,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteAzureRolesName(string name);
@@ -106,7 +106,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteConsulRolesName(string name);
@@ -116,7 +116,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteCubbyholePath(string path);
@@ -126,7 +126,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteGcpRolesetName(string name);
@@ -136,7 +136,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteGcpStaticAccountName(string name);
@@ -146,7 +146,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteGcpkmsConfig();
         /// <summary>
@@ -155,7 +155,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteGcpkmsKeysDeregisterKey(string key);
@@ -165,7 +165,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteGcpkmsKeysKey(string key);
@@ -175,7 +175,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteGcpkmsKeysTrimKey(string key);
@@ -185,7 +185,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteKubernetesConfig();
         /// <summary>
@@ -194,7 +194,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteKubernetesRolesName(string name);
@@ -204,7 +204,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteKvPath(string path);
@@ -214,7 +214,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteMongodbatlasRolesName(string name);
@@ -224,7 +224,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteNomadConfigAccess();
         /// <summary>
@@ -233,7 +233,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteNomadConfigLease();
         /// <summary>
@@ -242,7 +242,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteNomadRoleName(string name);
@@ -252,7 +252,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteOpenldapConfig();
         /// <summary>
@@ -261,7 +261,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteOpenldapRoleName(string name);
@@ -271,7 +271,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteOpenldapStaticRoleName(string name);
@@ -281,7 +281,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeletePkiIssuerRefDerPem(string issuerRef);
@@ -291,7 +291,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeletePkiJson();
         /// <summary>
@@ -300,7 +300,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeletePkiKeyKeyRef(string keyRef);
@@ -310,7 +310,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeletePkiRolesName(string name);
@@ -320,7 +320,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeletePkiRoot();
         /// <summary>
@@ -329,7 +329,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteRabbitmqRolesName(string name);
@@ -339,7 +339,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSecretDataPath(string path);
@@ -349,7 +349,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSecretMetadataPath(string path);
@@ -359,7 +359,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSshConfigCa();
         /// <summary>
@@ -368,7 +368,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSshConfigZeroaddress();
         /// <summary>
@@ -377,7 +377,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSshKeysKeyName(string keyName);
@@ -387,7 +387,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSshRolesRole(string role);
@@ -397,7 +397,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteTerraformConfig();
         /// <summary>
@@ -406,7 +406,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteTerraformRoleName(string name);
@@ -416,7 +416,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteTotpKeysName(string name);
@@ -426,7 +426,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteTransitKeysName(string name);
@@ -436,7 +436,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdConfig();
         /// <summary>
@@ -445,7 +445,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdCredsName(string name);
@@ -455,7 +455,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdLibrary(string list);
@@ -465,7 +465,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdLibraryName(string name);
@@ -475,7 +475,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdLibraryNameStatus(string name);
@@ -485,7 +485,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdRoles(string list);
@@ -495,7 +495,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdRolesName(string name);
@@ -505,7 +505,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAdRotateRoot();
         /// <summary>
@@ -514,7 +514,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAlicloudConfig();
         /// <summary>
@@ -523,7 +523,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAlicloudCredsName(string name);
@@ -533,7 +533,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAlicloudRole(string list);
@@ -543,7 +543,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAlicloudRoleName(string name);
@@ -553,7 +553,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAwsConfigLease();
         /// <summary>
@@ -562,7 +562,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAwsConfigRoot();
         /// <summary>
@@ -571,7 +571,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAwsCreds();
         /// <summary>
@@ -580,7 +580,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAwsRoles(string list);
@@ -590,7 +590,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAwsRolesName(string name);
@@ -600,7 +600,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAwsStsName(string name);
@@ -610,7 +610,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAzureConfig();
         /// <summary>
@@ -619,7 +619,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the Vault role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAzureCredsRole(string role);
@@ -629,7 +629,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAzureRoles(string list);
@@ -639,7 +639,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetAzureRolesName(string name);
@@ -649,7 +649,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetConsulConfigAccess();
         /// <summary>
@@ -658,7 +658,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetConsulCredsRole(string role);
@@ -668,7 +668,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetConsulRoles(string list);
@@ -678,7 +678,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetConsulRolesName(string name);
@@ -688,7 +688,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -699,7 +699,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpConfig();
         /// <summary>
@@ -708,7 +708,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpKeyRoleset(string roleset);
@@ -718,7 +718,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpRolesetName(string name);
@@ -728,7 +728,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpRolesetRolesetKey(string roleset);
@@ -738,7 +738,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpRolesetRolesetToken(string roleset);
@@ -748,7 +748,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpRolesets(string list);
@@ -758,7 +758,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpStaticAccountName(string name);
@@ -768,7 +768,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpStaticAccountNameKey(string name);
@@ -778,7 +778,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpStaticAccountNameToken(string name);
@@ -788,7 +788,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpStaticAccounts(string list);
@@ -798,7 +798,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpTokenRoleset(string roleset);
@@ -808,7 +808,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpkmsConfig();
         /// <summary>
@@ -817,7 +817,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpkmsKeys(string list);
@@ -827,7 +827,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpkmsKeysConfigKey(string key);
@@ -837,7 +837,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpkmsKeysKey(string key);
@@ -847,7 +847,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key for which to get the public key. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetGcpkmsPubkeyKey(string key);
@@ -857,7 +857,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetKubernetesConfig();
         /// <summary>
@@ -866,7 +866,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetKubernetesRoles(string list);
@@ -876,7 +876,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetKubernetesRolesName(string name);
@@ -886,7 +886,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -897,7 +897,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetMongodbatlasConfig();
         /// <summary>
@@ -906,7 +906,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetMongodbatlasCredsName(string name);
@@ -916,7 +916,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetMongodbatlasRoles(string list);
@@ -926,7 +926,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetMongodbatlasRolesName(string name);
@@ -936,7 +936,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetNomadConfigAccess();
         /// <summary>
@@ -945,7 +945,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetNomadConfigLease();
         /// <summary>
@@ -954,7 +954,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetNomadCredsName(string name);
@@ -964,7 +964,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetNomadRole(string list);
@@ -974,7 +974,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetNomadRoleName(string name);
@@ -984,7 +984,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetOpenldapConfig();
         /// <summary>
@@ -993,7 +993,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the dynamic role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetOpenldapCredsName(string name);
@@ -1003,7 +1003,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetOpenldapRole(string list);
@@ -1013,7 +1013,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetOpenldapRoleName(string name);
@@ -1023,7 +1023,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetOpenldapStaticCredName(string name);
@@ -1033,7 +1033,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetOpenldapStaticRole(string list);
@@ -1043,7 +1043,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetOpenldapStaticRoleName(string name);
@@ -1053,7 +1053,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCa();
         /// <summary>
@@ -1062,7 +1062,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCaChain();
         /// <summary>
@@ -1071,7 +1071,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCaPem();
         /// <summary>
@@ -1080,7 +1080,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCertCaChain();
         /// <summary>
@@ -1089,7 +1089,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCertCrl();
         /// <summary>
@@ -1098,7 +1098,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCertSerial(string serial);
@@ -1108,7 +1108,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCertSerialRaw(string serial);
@@ -1118,7 +1118,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCertSerialRawPem(string serial);
@@ -1128,7 +1128,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCerts(string list);
@@ -1138,7 +1138,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiConfigCrl();
         /// <summary>
@@ -1147,7 +1147,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiConfigIssuers();
         /// <summary>
@@ -1156,7 +1156,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiConfigKeys();
         /// <summary>
@@ -1165,7 +1165,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiConfigUrls();
         /// <summary>
@@ -1174,7 +1174,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCrl();
         /// <summary>
@@ -1183,7 +1183,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCrlPem();
         /// <summary>
@@ -1192,7 +1192,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiCrlRotate();
         /// <summary>
@@ -1201,7 +1201,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiDer();
         /// <summary>
@@ -1210,7 +1210,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiIssuerRefCrlPem(string issuerRef);
@@ -1220,7 +1220,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiIssuerRefDerPem(string issuerRef);
@@ -1230,7 +1230,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiIssuers(string list);
@@ -1240,7 +1240,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiJson();
         /// <summary>
@@ -1249,7 +1249,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiKeyKeyRef(string keyRef);
@@ -1259,7 +1259,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiKeys(string list);
@@ -1269,7 +1269,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiRoles(string list);
@@ -1279,7 +1279,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiRolesName(string name);
@@ -1289,7 +1289,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetPkiTidyStatus();
         /// <summary>
@@ -1298,7 +1298,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetRabbitmqConfigLease();
         /// <summary>
@@ -1307,7 +1307,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetRabbitmqCredsName(string name);
@@ -1317,7 +1317,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetRabbitmqRoles(string list);
@@ -1327,7 +1327,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetRabbitmqRolesName(string name);
@@ -1337,7 +1337,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSecretConfig();
         /// <summary>
@@ -1346,7 +1346,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSecretDataPath(string path);
@@ -1356,7 +1356,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1367,7 +1367,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSecretSubkeysPath(string path);
@@ -1377,7 +1377,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSshConfigCa();
         /// <summary>
@@ -1386,7 +1386,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSshConfigZeroaddress();
         /// <summary>
@@ -1395,7 +1395,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSshPublicKey();
         /// <summary>
@@ -1404,7 +1404,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSshRoles(string list);
@@ -1414,7 +1414,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSshRolesRole(string role);
@@ -1424,7 +1424,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTerraformConfig();
         /// <summary>
@@ -1433,7 +1433,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTerraformCredsName(string name);
@@ -1443,7 +1443,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTerraformRole(string list);
@@ -1453,7 +1453,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTerraformRoleName(string name);
@@ -1463,7 +1463,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTotpCodeName(string name);
@@ -1473,7 +1473,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTotpKeys(string list);
@@ -1483,7 +1483,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTotpKeysName(string name);
@@ -1493,7 +1493,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTransitBackupName(string name);
@@ -1503,7 +1503,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTransitCacheConfig();
         /// <summary>
@@ -1512,7 +1512,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1523,7 +1523,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <param name="version">Version of the key</param>
@@ -1535,7 +1535,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTransitKeys(string list);
@@ -1545,7 +1545,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTransitKeysName(string name);
@@ -1555,7 +1555,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetTransitWrappingKey();
         /// <summary>
@@ -1564,7 +1564,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="adConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAdConfig(AdConfigRequest adConfigRequest = default(AdConfigRequest));
@@ -1574,7 +1574,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryManageCheckInRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1585,7 +1585,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1596,7 +1596,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryCheckInRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1607,7 +1607,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set</param>
         /// <param name="adLibraryCheckOutRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1618,7 +1618,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="adRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1629,7 +1629,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAdRotateRoleName(string name);
@@ -1639,7 +1639,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAdRotateRoot();
         /// <summary>
@@ -1648,7 +1648,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAlicloudConfig(AlicloudConfigRequest alicloudConfigRequest = default(AlicloudConfigRequest));
@@ -1658,7 +1658,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1669,7 +1669,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAwsConfigLease(AwsConfigLeaseRequest awsConfigLeaseRequest = default(AwsConfigLeaseRequest));
@@ -1679,7 +1679,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigRootRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAwsConfigRoot(AwsConfigRootRequest awsConfigRootRequest = default(AwsConfigRootRequest));
@@ -1689,7 +1689,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAwsConfigRotateRoot();
         /// <summary>
@@ -1698,7 +1698,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsCredsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAwsCreds(AwsCredsRequest awsCredsRequest = default(AwsCredsRequest));
@@ -1708,7 +1708,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="awsRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1719,7 +1719,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="awsStsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1730,7 +1730,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAzureConfig(AzureConfigRequest azureConfigRequest = default(AzureConfigRequest));
@@ -1740,7 +1740,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1751,7 +1751,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostAzureRotateRoot();
         /// <summary>
@@ -1760,7 +1760,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="consulConfigAccessRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostConsulConfigAccess(ConsulConfigAccessRequest consulConfigAccessRequest = default(ConsulConfigAccessRequest));
@@ -1770,7 +1770,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="consulRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1781,7 +1781,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostCubbyholePath(string path);
@@ -1791,7 +1791,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpConfig(GcpConfigRequest gcpConfigRequest = default(GcpConfigRequest));
@@ -1801,7 +1801,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpConfigRotateRoot();
         /// <summary>
@@ -1810,7 +1810,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1821,7 +1821,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="gcpRolesetRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1832,7 +1832,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpRolesetNameRotate(string name);
@@ -1842,7 +1842,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpRolesetNameRotateKey(string name);
@@ -1852,7 +1852,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpRolesetKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1863,7 +1863,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpRolesetRolesetToken(string roleset);
@@ -1873,7 +1873,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="gcpStaticAccountRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1884,7 +1884,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="gcpStaticAccountKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1895,7 +1895,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpStaticAccountNameRotateKey(string name);
@@ -1905,7 +1905,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpStaticAccountNameToken(string name);
@@ -1915,7 +1915,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpTokenRoleset(string roleset);
@@ -1925,7 +1925,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpkmsConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpkmsConfig(GcpkmsConfigRequest gcpkmsConfigRequest = default(GcpkmsConfigRequest));
@@ -1935,7 +1935,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for decryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsDecryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1946,7 +1946,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for encryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsEncryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1957,7 +1957,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1968,7 +1968,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpkmsKeysDeregisterKey(string key);
@@ -1978,7 +1978,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1989,7 +1989,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to register in Vault. This will be the named used to refer to the underlying crypto key when encrypting or decrypting data.</param>
         /// <param name="gcpkmsKeysRegisterRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2000,7 +2000,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to rotate. This key must already be registered with Vault and point to a valid Google Cloud KMS crypto key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpkmsKeysRotateKey(string key);
@@ -2010,7 +2010,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostGcpkmsKeysTrimKey(string key);
@@ -2020,7 +2020,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to use for encryption. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <param name="gcpkmsReencryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2031,7 +2031,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for signing. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2042,7 +2042,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for verification. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2053,7 +2053,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostKubernetesConfig(KubernetesConfigRequest kubernetesConfigRequest = default(KubernetesConfigRequest));
@@ -2063,7 +2063,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Vault role</param>
         /// <param name="kubernetesCredsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2074,7 +2074,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="kubernetesRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2085,7 +2085,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostKvPath(string path);
@@ -2095,7 +2095,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="mongodbatlasConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostMongodbatlasConfig(MongodbatlasConfigRequest mongodbatlasConfigRequest = default(MongodbatlasConfigRequest));
@@ -2105,7 +2105,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostMongodbatlasCredsName(string name);
@@ -2115,7 +2115,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="mongodbatlasRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2126,7 +2126,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigAccessRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostNomadConfigAccess(NomadConfigAccessRequest nomadConfigAccessRequest = default(NomadConfigAccessRequest));
@@ -2136,7 +2136,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostNomadConfigLease(NomadConfigLeaseRequest nomadConfigLeaseRequest = default(NomadConfigLeaseRequest));
@@ -2146,7 +2146,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="nomadRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2157,7 +2157,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="openldapConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostOpenldapConfig(OpenldapConfigRequest openldapConfigRequest = default(OpenldapConfigRequest));
@@ -2167,7 +2167,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="openldapRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2178,7 +2178,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostOpenldapRotateRoleName(string name);
@@ -2188,7 +2188,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostOpenldapRotateRoot();
         /// <summary>
@@ -2197,7 +2197,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="openldapStaticRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2208,7 +2208,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiBundleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiBundle(PkiBundleRequest pkiBundleRequest = default(PkiBundleRequest));
@@ -2218,7 +2218,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiCertRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiCert(PkiCertRequest pkiCertRequest = default(PkiCertRequest));
@@ -2228,7 +2228,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiConfigCa(PkiConfigCaRequest pkiConfigCaRequest = default(PkiConfigCaRequest));
@@ -2238,7 +2238,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCrlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiConfigCrl(PkiConfigCrlRequest pkiConfigCrlRequest = default(PkiConfigCrlRequest));
@@ -2248,7 +2248,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigIssuersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiConfigIssuers(PkiConfigIssuersRequest pkiConfigIssuersRequest = default(PkiConfigIssuersRequest));
@@ -2258,7 +2258,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiConfigKeys(PkiConfigKeysRequest pkiConfigKeysRequest = default(PkiConfigKeysRequest));
@@ -2268,7 +2268,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigUrlsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiConfigUrls(PkiConfigUrlsRequest pkiConfigUrlsRequest = default(PkiConfigUrlsRequest));
@@ -2278,7 +2278,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateCrossSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiIntermediateCrossSign(PkiIntermediateCrossSignRequest pkiIntermediateCrossSignRequest = default(PkiIntermediateCrossSignRequest));
@@ -2288,7 +2288,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIntermediateGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2299,7 +2299,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateSetSignedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiIntermediateSetSigned(PkiIntermediateSetSignedRequest pkiIntermediateSetSignedRequest = default(PkiIntermediateSetSignedRequest));
@@ -2309,7 +2309,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiInternalExportedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiInternalExported(PkiInternalExportedRequest pkiInternalExportedRequest = default(PkiInternalExportedRequest));
@@ -2319,7 +2319,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssueRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2330,7 +2330,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerIssueRequest"> (optional)</param>
@@ -2342,7 +2342,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignIntermediateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2353,7 +2353,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignRequest"> (optional)</param>
@@ -2365,7 +2365,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignSelfIssuedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2376,7 +2376,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2387,7 +2387,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
@@ -2399,7 +2399,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiDerPemRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2410,7 +2410,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateIntermediateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2421,7 +2421,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateRootRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2432,7 +2432,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiJsonRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiJson(PkiJsonRequest pkiJsonRequest = default(PkiJsonRequest));
@@ -2442,7 +2442,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="pkiKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2453,7 +2453,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKeysImportRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiKeysImport(PkiKeysImportRequest pkiKeysImportRequest = default(PkiKeysImportRequest));
@@ -2463,7 +2463,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKmsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiKms(PkiKmsRequest pkiKmsRequest = default(PkiKmsRequest));
@@ -2473,7 +2473,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiRevoke(PkiRevokeRequest pkiRevokeRequest = default(PkiRevokeRequest));
@@ -2483,7 +2483,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="pkiRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2494,7 +2494,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2505,7 +2505,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootReplaceRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiRootReplace(PkiRootReplaceRequest pkiRootReplaceRequest = default(PkiRootReplaceRequest));
@@ -2515,7 +2515,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootRotateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2526,7 +2526,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignIntermediateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiRootSignIntermediate(PkiRootSignIntermediateRequest pkiRootSignIntermediateRequest = default(PkiRootSignIntermediateRequest));
@@ -2536,7 +2536,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignSelfIssuedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiRootSignSelfIssued(PkiRootSignSelfIssuedRequest pkiRootSignSelfIssuedRequest = default(PkiRootSignSelfIssuedRequest));
@@ -2546,7 +2546,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2557,7 +2557,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiSignVerbatim(PkiSignVerbatimRequest pkiSignVerbatimRequest = default(PkiSignVerbatimRequest));
@@ -2567,7 +2567,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2578,7 +2578,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiTidyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostPkiTidy(PkiTidyRequest pkiTidyRequest = default(PkiTidyRequest));
@@ -2588,7 +2588,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigConnectionRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostRabbitmqConfigConnection(RabbitmqConfigConnectionRequest rabbitmqConfigConnectionRequest = default(RabbitmqConfigConnectionRequest));
@@ -2598,7 +2598,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostRabbitmqConfigLease(RabbitmqConfigLeaseRequest rabbitmqConfigLeaseRequest = default(RabbitmqConfigLeaseRequest));
@@ -2608,7 +2608,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="rabbitmqRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2619,7 +2619,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kvConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSecretConfig(KvConfigRequest kvConfigRequest = default(KvConfigRequest));
@@ -2629,7 +2629,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDataRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2640,7 +2640,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDeleteRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2651,7 +2651,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2662,7 +2662,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvMetadataRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2673,7 +2673,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvUndeleteRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2684,7 +2684,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigCaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSshConfigCa(SshConfigCaRequest sshConfigCaRequest = default(SshConfigCaRequest));
@@ -2694,7 +2694,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigZeroaddressRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSshConfigZeroaddress(SshConfigZeroaddressRequest sshConfigZeroaddressRequest = default(SshConfigZeroaddressRequest));
@@ -2704,7 +2704,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required] Name of the role</param>
         /// <param name="sshCredsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2715,7 +2715,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <param name="sshKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2726,7 +2726,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSshLookup(SshLookupRequest sshLookupRequest = default(SshLookupRequest));
@@ -2736,7 +2736,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="sshRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2747,7 +2747,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request.</param>
         /// <param name="sshSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2758,7 +2758,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSshVerify(SshVerifyRequest sshVerifyRequest = default(SshVerifyRequest));
@@ -2768,7 +2768,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="terraformConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTerraformConfig(TerraformConfigRequest terraformConfigRequest = default(TerraformConfigRequest));
@@ -2778,7 +2778,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTerraformCredsName(string name);
@@ -2788,7 +2788,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="terraformRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2799,7 +2799,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the team or organization role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTerraformRotateRoleName(string name);
@@ -2809,7 +2809,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpCodeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2820,7 +2820,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2831,7 +2831,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitCacheConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTransitCacheConfig(TransitCacheConfigRequest transitCacheConfigRequest = default(TransitCacheConfigRequest));
@@ -2841,7 +2841,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The backend key used for encrypting the data key</param>
         /// <param name="plaintext">\&quot;plaintext\&quot; will return the key in both plaintext and ciphertext; \&quot;wrapped\&quot; will return the ciphertext only.</param>
         /// <param name="transitDatakeyRequest"> (optional)</param>
@@ -2853,7 +2853,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitDecryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2864,7 +2864,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitEncryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2875,7 +2875,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTransitHash(TransitHashRequest transitHashRequest = default(TransitHashRequest));
@@ -2885,7 +2885,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2896,7 +2896,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="transitHmacRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2907,7 +2907,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHmacRequest"> (optional)</param>
@@ -2919,7 +2919,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2930,7 +2930,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2941,7 +2941,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2952,7 +2952,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportVersionRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2963,7 +2963,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTransitKeysNameRotate(string name);
@@ -2973,7 +2973,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysTrimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -2984,7 +2984,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTransitRandom(TransitRandomRequest transitRandomRequest = default(TransitRandomRequest));
@@ -2994,7 +2994,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -3005,7 +3005,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
@@ -3017,7 +3017,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -3028,7 +3028,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostTransitRestore(TransitRestoreRequest transitRestoreRequest = default(TransitRestoreRequest));
@@ -3038,7 +3038,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">If set, this will be the name of the restored key.</param>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -3049,7 +3049,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitRewrapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -3060,7 +3060,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -3071,7 +3071,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitSignRequest"> (optional)</param>
@@ -3083,7 +3083,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -3094,7 +3094,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
@@ -3116,7 +3116,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAdConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3127,7 +3127,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3139,7 +3139,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3151,7 +3151,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAlicloudConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3162,7 +3162,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3174,7 +3174,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3186,7 +3186,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3197,7 +3197,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3209,7 +3209,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3221,7 +3221,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3233,7 +3233,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3245,7 +3245,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3257,7 +3257,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteGcpkmsConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3268,7 +3268,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3280,7 +3280,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3292,7 +3292,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3304,7 +3304,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteKubernetesConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3315,7 +3315,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3327,7 +3327,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3339,7 +3339,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3351,7 +3351,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteNomadConfigAccessAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3362,7 +3362,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteNomadConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3373,7 +3373,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3385,7 +3385,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteOpenldapConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3396,7 +3396,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3408,7 +3408,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3420,7 +3420,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3432,7 +3432,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeletePkiJsonAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3443,7 +3443,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3455,7 +3455,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3467,7 +3467,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeletePkiRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3478,7 +3478,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3490,7 +3490,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3502,7 +3502,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3514,7 +3514,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSshConfigCaAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3525,7 +3525,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSshConfigZeroaddressAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3536,7 +3536,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3548,7 +3548,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3560,7 +3560,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteTerraformConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3571,7 +3571,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3583,7 +3583,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3595,7 +3595,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3607,7 +3607,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAdConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3618,7 +3618,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3630,7 +3630,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3642,7 +3642,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3654,7 +3654,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3666,7 +3666,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3678,7 +3678,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3690,7 +3690,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAdRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3701,7 +3701,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAlicloudConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3712,7 +3712,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3724,7 +3724,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3736,7 +3736,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3748,7 +3748,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAwsConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3759,7 +3759,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAwsConfigRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3770,7 +3770,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAwsCredsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3781,7 +3781,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3793,7 +3793,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3805,7 +3805,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3817,7 +3817,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3828,7 +3828,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the Vault role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3840,7 +3840,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3852,7 +3852,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3864,7 +3864,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetConsulConfigAccessAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3875,7 +3875,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3887,7 +3887,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3899,7 +3899,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3911,7 +3911,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3924,7 +3924,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetGcpConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3935,7 +3935,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3947,7 +3947,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3959,7 +3959,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3971,7 +3971,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3983,7 +3983,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3995,7 +3995,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4007,7 +4007,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4019,7 +4019,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4031,7 +4031,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4043,7 +4043,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4055,7 +4055,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetGcpkmsConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4066,7 +4066,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4078,7 +4078,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4090,7 +4090,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4102,7 +4102,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key for which to get the public key. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4114,7 +4114,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetKubernetesConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4125,7 +4125,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4137,7 +4137,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4149,7 +4149,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4162,7 +4162,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetMongodbatlasConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4173,7 +4173,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4185,7 +4185,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4197,7 +4197,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4209,7 +4209,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetNomadConfigAccessAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4220,7 +4220,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetNomadConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4231,7 +4231,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4243,7 +4243,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4255,7 +4255,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4267,7 +4267,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetOpenldapConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4278,7 +4278,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the dynamic role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4290,7 +4290,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4302,7 +4302,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4314,7 +4314,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4326,7 +4326,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4338,7 +4338,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4350,7 +4350,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCaAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4361,7 +4361,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCaChainAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4372,7 +4372,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCaPemAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4383,7 +4383,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCertCaChainAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4394,7 +4394,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCertCrlAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4405,7 +4405,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4417,7 +4417,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4429,7 +4429,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4441,7 +4441,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4453,7 +4453,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiConfigCrlAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4464,7 +4464,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiConfigIssuersAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4475,7 +4475,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiConfigKeysAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4486,7 +4486,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiConfigUrlsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4497,7 +4497,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCrlAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4508,7 +4508,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCrlPemAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4519,7 +4519,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiCrlRotateAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4530,7 +4530,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiDerAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4541,7 +4541,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4553,7 +4553,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4565,7 +4565,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4577,7 +4577,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiJsonAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4588,7 +4588,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4600,7 +4600,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4612,7 +4612,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4624,7 +4624,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4636,7 +4636,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetPkiTidyStatusAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4647,7 +4647,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetRabbitmqConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4658,7 +4658,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4670,7 +4670,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4682,7 +4682,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4694,7 +4694,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSecretConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4705,7 +4705,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4717,7 +4717,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4730,7 +4730,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4742,7 +4742,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSshConfigCaAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4753,7 +4753,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSshConfigZeroaddressAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4764,7 +4764,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSshPublicKeyAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4775,7 +4775,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4787,7 +4787,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4799,7 +4799,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetTerraformConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4810,7 +4810,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4822,7 +4822,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4834,7 +4834,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4846,7 +4846,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4858,7 +4858,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4870,7 +4870,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4882,7 +4882,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4894,7 +4894,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetTransitCacheConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4905,7 +4905,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4918,7 +4918,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <param name="version">Version of the key</param>
@@ -4932,7 +4932,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4944,7 +4944,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4956,7 +4956,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetTransitWrappingKeyAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -4967,7 +4967,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="adConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4979,7 +4979,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryManageCheckInRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4992,7 +4992,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5005,7 +5005,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryCheckInRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5018,7 +5018,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set</param>
         /// <param name="adLibraryCheckOutRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5031,7 +5031,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="adRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5044,7 +5044,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5056,7 +5056,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAdRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5067,7 +5067,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5079,7 +5079,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5092,7 +5092,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5104,7 +5104,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigRootRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5116,7 +5116,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAwsConfigRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5127,7 +5127,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsCredsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5139,7 +5139,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="awsRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5152,7 +5152,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="awsStsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5165,7 +5165,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5177,7 +5177,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5190,7 +5190,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostAzureRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5201,7 +5201,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="consulConfigAccessRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5213,7 +5213,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="consulRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5226,7 +5226,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5238,7 +5238,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5250,7 +5250,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostGcpConfigRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5261,7 +5261,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5274,7 +5274,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="gcpRolesetRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5287,7 +5287,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5299,7 +5299,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5311,7 +5311,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpRolesetKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5324,7 +5324,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5336,7 +5336,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="gcpStaticAccountRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5349,7 +5349,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="gcpStaticAccountKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5362,7 +5362,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5374,7 +5374,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5386,7 +5386,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5398,7 +5398,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpkmsConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5410,7 +5410,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for decryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsDecryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5423,7 +5423,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for encryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsEncryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5436,7 +5436,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5449,7 +5449,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5461,7 +5461,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5474,7 +5474,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to register in Vault. This will be the named used to refer to the underlying crypto key when encrypting or decrypting data.</param>
         /// <param name="gcpkmsKeysRegisterRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5487,7 +5487,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to rotate. This key must already be registered with Vault and point to a valid Google Cloud KMS crypto key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5499,7 +5499,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5511,7 +5511,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to use for encryption. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <param name="gcpkmsReencryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5524,7 +5524,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for signing. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5537,7 +5537,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for verification. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5550,7 +5550,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5562,7 +5562,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Vault role</param>
         /// <param name="kubernetesCredsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5575,7 +5575,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="kubernetesRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5588,7 +5588,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5600,7 +5600,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="mongodbatlasConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5612,7 +5612,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5624,7 +5624,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="mongodbatlasRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5637,7 +5637,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigAccessRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5649,7 +5649,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5661,7 +5661,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="nomadRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5674,7 +5674,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="openldapConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5686,7 +5686,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="openldapRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5699,7 +5699,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5711,7 +5711,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostOpenldapRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -5722,7 +5722,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="openldapStaticRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5735,7 +5735,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiBundleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5747,7 +5747,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiCertRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5759,7 +5759,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5771,7 +5771,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCrlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5783,7 +5783,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigIssuersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5795,7 +5795,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5807,7 +5807,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigUrlsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5819,7 +5819,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateCrossSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5831,7 +5831,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIntermediateGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5844,7 +5844,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateSetSignedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5856,7 +5856,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiInternalExportedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5868,7 +5868,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssueRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5881,7 +5881,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerIssueRequest"> (optional)</param>
@@ -5895,7 +5895,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignIntermediateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5908,7 +5908,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignRequest"> (optional)</param>
@@ -5922,7 +5922,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignSelfIssuedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5935,7 +5935,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5948,7 +5948,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
@@ -5962,7 +5962,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiDerPemRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5975,7 +5975,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateIntermediateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -5988,7 +5988,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateRootRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6001,7 +6001,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiJsonRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6013,7 +6013,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="pkiKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6026,7 +6026,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKeysImportRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6038,7 +6038,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKmsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6050,7 +6050,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6062,7 +6062,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="pkiRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6075,7 +6075,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6088,7 +6088,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootReplaceRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6100,7 +6100,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootRotateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6113,7 +6113,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignIntermediateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6125,7 +6125,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignSelfIssuedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6137,7 +6137,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6150,7 +6150,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6162,7 +6162,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6175,7 +6175,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiTidyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6187,7 +6187,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigConnectionRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6199,7 +6199,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6211,7 +6211,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="rabbitmqRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6224,7 +6224,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kvConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6236,7 +6236,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDataRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6249,7 +6249,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDeleteRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6262,7 +6262,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6275,7 +6275,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvMetadataRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6288,7 +6288,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvUndeleteRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6301,7 +6301,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigCaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6313,7 +6313,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigZeroaddressRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6325,7 +6325,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required] Name of the role</param>
         /// <param name="sshCredsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6338,7 +6338,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <param name="sshKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6351,7 +6351,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6363,7 +6363,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="sshRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6376,7 +6376,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request.</param>
         /// <param name="sshSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6389,7 +6389,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6401,7 +6401,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="terraformConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6413,7 +6413,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6425,7 +6425,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="terraformRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6438,7 +6438,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the team or organization role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6450,7 +6450,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpCodeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6463,7 +6463,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6476,7 +6476,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitCacheConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6488,7 +6488,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The backend key used for encrypting the data key</param>
         /// <param name="plaintext">\&quot;plaintext\&quot; will return the key in both plaintext and ciphertext; \&quot;wrapped\&quot; will return the ciphertext only.</param>
         /// <param name="transitDatakeyRequest"> (optional)</param>
@@ -6502,7 +6502,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitDecryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6515,7 +6515,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitEncryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6528,7 +6528,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6540,7 +6540,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6553,7 +6553,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="transitHmacRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6566,7 +6566,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHmacRequest"> (optional)</param>
@@ -6580,7 +6580,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6593,7 +6593,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6606,7 +6606,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6619,7 +6619,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportVersionRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6632,7 +6632,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6644,7 +6644,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysTrimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6657,7 +6657,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6669,7 +6669,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6682,7 +6682,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
@@ -6696,7 +6696,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6709,7 +6709,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6721,7 +6721,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">If set, this will be the name of the restored key.</param>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6734,7 +6734,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitRewrapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6747,7 +6747,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6760,7 +6760,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitSignRequest"> (optional)</param>
@@ -6774,7 +6774,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -6787,7 +6787,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
@@ -6819,7 +6819,7 @@ namespace Vault.Api
             this.Configuration = apiClient.Configuration;
             this.Client = apiClient;
             this.AsynchronousClient = apiClient;
-            this.ExceptionFactory = Vault.Client.Configuration.DefaultExceptionFactory;
+            this.ExceptionFactory = Configuration.DefaultExceptionFactory;
         }
 
         /// <summary>
@@ -6867,7 +6867,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the AD server to connect to, along with password options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAdConfig()
         {
@@ -6903,7 +6903,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the AD server to connect to, along with password options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAdConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6941,14 +6941,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAdLibraryName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdLibraryName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdLibraryName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -6983,7 +6983,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -6991,7 +6991,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdLibraryName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdLibraryName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7027,14 +7027,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage roles to build links between Vault and Active Directory service accounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAdRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7069,7 +7069,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage roles to build links between Vault and Active Directory service accounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7077,7 +7077,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAdRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7113,7 +7113,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the access key and secret to use for RAM and STS calls. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAlicloudConfig()
         {
@@ -7149,7 +7149,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the access key and secret to use for RAM and STS calls. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAlicloudConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7187,14 +7187,14 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference policies and roles that API keys or STS credentials can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAlicloudRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAlicloudRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAlicloudRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7229,7 +7229,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference policies and roles that API keys or STS credentials can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7237,7 +7237,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAlicloudRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAlicloudRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7273,14 +7273,14 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference IAM policies that access keys can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAwsRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAwsRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAwsRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7315,7 +7315,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference IAM policies that access keys can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7323,7 +7323,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAwsRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAwsRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7359,7 +7359,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAzureConfig()
         {
@@ -7395,7 +7395,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7433,14 +7433,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the Vault roles used to generate Azure credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteAzureRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAzureRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAzureRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7475,7 +7475,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the Vault roles used to generate Azure credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7483,7 +7483,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAzureRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteAzureRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7519,14 +7519,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteConsulRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteConsulRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteConsulRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7561,7 +7561,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7569,7 +7569,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteConsulRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteConsulRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7605,14 +7605,14 @@ namespace Vault.Api
         /// <summary>
         /// Deletes the secret at the specified location. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteCubbyholePath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteCubbyholePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteCubbyholePath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7647,7 +7647,7 @@ namespace Vault.Api
         /// <summary>
         /// Deletes the secret at the specified location. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7655,7 +7655,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteCubbyholePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteCubbyholePath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7691,14 +7691,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteGcpRolesetName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpRolesetName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpRolesetName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7733,7 +7733,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7741,7 +7741,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpRolesetName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpRolesetName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7777,14 +7777,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteGcpStaticAccountName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpStaticAccountName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpStaticAccountName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7819,7 +7819,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7827,7 +7827,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpStaticAccountName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteGcpStaticAccountName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7863,7 +7863,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the GCP KMS secrets engine 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteGcpkmsConfig()
         {
@@ -7899,7 +7899,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the GCP KMS secrets engine 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteGcpkmsConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7937,14 +7937,14 @@ namespace Vault.Api
         /// <summary>
         /// Deregister an existing key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteGcpkmsKeysDeregisterKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysDeregisterKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysDeregisterKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7979,7 +7979,7 @@ namespace Vault.Api
         /// <summary>
         /// Deregister an existing key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7987,7 +7987,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysDeregisterKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysDeregisterKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8023,14 +8023,14 @@ namespace Vault.Api
         /// <summary>
         /// Interact with crypto keys in Vault and Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteGcpkmsKeysKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8065,7 +8065,7 @@ namespace Vault.Api
         /// <summary>
         /// Interact with crypto keys in Vault and Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8073,7 +8073,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8109,14 +8109,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete old crypto key versions from Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteGcpkmsKeysTrimKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysTrimKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysTrimKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8151,7 +8151,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete old crypto key versions from Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8159,7 +8159,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysTrimKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->DeleteGcpkmsKeysTrimKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8195,7 +8195,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteKubernetesConfig()
         {
@@ -8231,7 +8231,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteKubernetesConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8269,14 +8269,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteKubernetesRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteKubernetesRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteKubernetesRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8311,7 +8311,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8319,7 +8319,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteKubernetesRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteKubernetesRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8355,14 +8355,14 @@ namespace Vault.Api
         /// <summary>
         /// Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteKvPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteKvPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteKvPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8397,7 +8397,7 @@ namespace Vault.Api
         /// <summary>
         /// Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8405,7 +8405,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteKvPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteKvPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8441,14 +8441,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles used to generate MongoDB Atlas Programmatic API Keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteMongodbatlasRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteMongodbatlasRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteMongodbatlasRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8483,7 +8483,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles used to generate MongoDB Atlas Programmatic API Keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8491,7 +8491,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteMongodbatlasRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteMongodbatlasRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8527,7 +8527,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteNomadConfigAccess()
         {
@@ -8563,7 +8563,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteNomadConfigAccessAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8601,7 +8601,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated tokens 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteNomadConfigLease()
         {
@@ -8637,7 +8637,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated tokens 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteNomadConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8675,14 +8675,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteNomadRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteNomadRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteNomadRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8717,7 +8717,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8725,7 +8725,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteNomadRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteNomadRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8761,7 +8761,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteOpenldapConfig()
         {
@@ -8797,7 +8797,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteOpenldapConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8835,14 +8835,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteOpenldapRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8877,7 +8877,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8885,7 +8885,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8921,14 +8921,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteOpenldapStaticRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapStaticRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapStaticRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8963,7 +8963,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8971,7 +8971,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapStaticRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteOpenldapStaticRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9007,14 +9007,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeletePkiIssuerRefDerPem(string issuerRef)
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->DeletePkiIssuerRefDerPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->DeletePkiIssuerRefDerPem");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9049,7 +9049,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9057,7 +9057,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->DeletePkiIssuerRefDerPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->DeletePkiIssuerRefDerPem");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9093,7 +9093,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeletePkiJson()
         {
@@ -9129,7 +9129,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeletePkiJsonAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9167,14 +9167,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeletePkiKeyKeyRef(string keyRef)
         {
             // verify the required parameter 'keyRef' is set
             if (keyRef == null)
-                throw new ApiException(400, "Missing required parameter 'keyRef' when calling Secrets->DeletePkiKeyKeyRef");
+                throw new VaultApiException(400, "Missing required parameter 'keyRef' when calling Secrets->DeletePkiKeyKeyRef");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9209,7 +9209,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9217,7 +9217,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'keyRef' is set
             if (keyRef == null)
-                throw new ApiException(400, "Missing required parameter 'keyRef' when calling Secrets->DeletePkiKeyKeyRef");
+                throw new VaultApiException(400, "Missing required parameter 'keyRef' when calling Secrets->DeletePkiKeyKeyRef");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9253,14 +9253,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeletePkiRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeletePkiRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeletePkiRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9295,7 +9295,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9303,7 +9303,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeletePkiRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeletePkiRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9339,7 +9339,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeletePkiRoot()
         {
@@ -9375,7 +9375,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeletePkiRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9413,14 +9413,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteRabbitmqRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteRabbitmqRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteRabbitmqRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9455,7 +9455,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9463,7 +9463,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteRabbitmqRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteRabbitmqRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9499,14 +9499,14 @@ namespace Vault.Api
         /// <summary>
         /// Write, Patch, Read, and Delete data in the Key-Value Store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSecretDataPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretDataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretDataPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9541,7 +9541,7 @@ namespace Vault.Api
         /// <summary>
         /// Write, Patch, Read, and Delete data in the Key-Value Store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9549,7 +9549,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretDataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretDataPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9585,14 +9585,14 @@ namespace Vault.Api
         /// <summary>
         /// Configures settings for the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSecretMetadataPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretMetadataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretMetadataPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9627,7 +9627,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures settings for the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9635,7 +9635,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretMetadataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->DeleteSecretMetadataPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9671,7 +9671,7 @@ namespace Vault.Api
         /// <summary>
         /// Set the SSH private key used for signing certificates. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSshConfigCa()
         {
@@ -9707,7 +9707,7 @@ namespace Vault.Api
         /// <summary>
         /// Set the SSH private key used for signing certificates. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSshConfigCaAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9745,7 +9745,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign zero address as default CIDR block for select roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSshConfigZeroaddress()
         {
@@ -9781,7 +9781,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign zero address as default CIDR block for select roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSshConfigZeroaddressAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9819,14 +9819,14 @@ namespace Vault.Api
         /// <summary>
         /// Register a shared private key with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSshKeysKeyName(string keyName)
         {
             // verify the required parameter 'keyName' is set
             if (keyName == null)
-                throw new ApiException(400, "Missing required parameter 'keyName' when calling Secrets->DeleteSshKeysKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'keyName' when calling Secrets->DeleteSshKeysKeyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9861,7 +9861,7 @@ namespace Vault.Api
         /// <summary>
         /// Register a shared private key with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9869,7 +9869,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'keyName' is set
             if (keyName == null)
-                throw new ApiException(400, "Missing required parameter 'keyName' when calling Secrets->DeleteSshKeysKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'keyName' when calling Secrets->DeleteSshKeysKeyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9905,14 +9905,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSshRolesRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->DeleteSshRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->DeleteSshRolesRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9947,7 +9947,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9955,7 +9955,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->DeleteSshRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->DeleteSshRolesRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9991,7 +9991,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteTerraformConfig()
         {
@@ -10027,7 +10027,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteTerraformConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10065,14 +10065,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteTerraformRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTerraformRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTerraformRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10107,7 +10107,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10115,7 +10115,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTerraformRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTerraformRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10151,14 +10151,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteTotpKeysName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTotpKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTotpKeysName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10193,7 +10193,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10201,7 +10201,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTotpKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTotpKeysName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10237,14 +10237,14 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteTransitKeysName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTransitKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTransitKeysName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10279,7 +10279,7 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10287,7 +10287,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTransitKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->DeleteTransitKeysName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10323,7 +10323,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the AD server to connect to, along with password options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdConfig()
         {
@@ -10359,7 +10359,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the AD server to connect to, along with password options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAdConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10397,14 +10397,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10439,7 +10439,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10447,7 +10447,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10483,14 +10483,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdLibrary(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdLibrary");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdLibrary");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10525,7 +10525,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10533,7 +10533,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdLibrary");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdLibrary");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10569,14 +10569,14 @@ namespace Vault.Api
         /// <summary>
         /// Read a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdLibraryName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10611,7 +10611,7 @@ namespace Vault.Api
         /// <summary>
         /// Read a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10619,7 +10619,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10655,14 +10655,14 @@ namespace Vault.Api
         /// <summary>
         /// Check the status of the service accounts in a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdLibraryNameStatus(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryNameStatus");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryNameStatus");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10697,7 +10697,7 @@ namespace Vault.Api
         /// <summary>
         /// Check the status of the service accounts in a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10705,7 +10705,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryNameStatus");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdLibraryNameStatus");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10741,14 +10741,14 @@ namespace Vault.Api
         /// <summary>
         /// List the name of each role currently stored. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10783,7 +10783,7 @@ namespace Vault.Api
         /// <summary>
         /// List the name of each role currently stored. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10791,7 +10791,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAdRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10827,14 +10827,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage roles to build links between Vault and Active Directory service accounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10869,7 +10869,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage roles to build links between Vault and Active Directory service accounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10877,7 +10877,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAdRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10913,7 +10913,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAdRotateRoot()
         {
@@ -10949,7 +10949,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAdRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10987,7 +10987,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the access key and secret to use for RAM and STS calls. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAlicloudConfig()
         {
@@ -11023,7 +11023,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the access key and secret to use for RAM and STS calls. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAlicloudConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11061,14 +11061,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate an API key or STS credential using the given role&#39;s configuration.&#39; 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAlicloudCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11103,7 +11103,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an API key or STS credential using the given role&#39;s configuration.&#39; 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11111,7 +11111,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11147,14 +11147,14 @@ namespace Vault.Api
         /// <summary>
         /// List the existing roles in this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAlicloudRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAlicloudRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAlicloudRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11189,7 +11189,7 @@ namespace Vault.Api
         /// <summary>
         /// List the existing roles in this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11197,7 +11197,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAlicloudRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAlicloudRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11233,14 +11233,14 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference policies and roles that API keys or STS credentials can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAlicloudRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11275,7 +11275,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference policies and roles that API keys or STS credentials can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11283,7 +11283,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAlicloudRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11319,7 +11319,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the default lease information for generated credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAwsConfigLease()
         {
@@ -11355,7 +11355,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the default lease information for generated credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAwsConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11393,7 +11393,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the root credentials that are used to manage IAM. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAwsConfigRoot()
         {
@@ -11429,7 +11429,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the root credentials that are used to manage IAM. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAwsConfigRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11467,7 +11467,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAwsCreds()
         {
@@ -11503,7 +11503,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAwsCredsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11541,14 +11541,14 @@ namespace Vault.Api
         /// <summary>
         /// List the existing roles in this backend 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAwsRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAwsRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAwsRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11583,7 +11583,7 @@ namespace Vault.Api
         /// <summary>
         /// List the existing roles in this backend 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11591,7 +11591,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAwsRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAwsRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11627,14 +11627,14 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference IAM policies that access keys can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAwsRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11669,7 +11669,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference IAM policies that access keys can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11677,7 +11677,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11713,14 +11713,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAwsStsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsStsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsStsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11755,7 +11755,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11763,7 +11763,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsStsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAwsStsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11799,7 +11799,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAzureConfig()
         {
@@ -11835,7 +11835,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetAzureConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11873,14 +11873,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the Vault role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAzureCredsRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->GetAzureCredsRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->GetAzureCredsRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11915,7 +11915,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the Vault role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11923,7 +11923,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->GetAzureCredsRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->GetAzureCredsRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11959,14 +11959,14 @@ namespace Vault.Api
         /// <summary>
         /// List existing roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAzureRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAzureRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAzureRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12001,7 +12001,7 @@ namespace Vault.Api
         /// <summary>
         /// List existing roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12009,7 +12009,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetAzureRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetAzureRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12045,14 +12045,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the Vault roles used to generate Azure credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetAzureRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAzureRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAzureRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12087,7 +12087,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the Vault roles used to generate Azure credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12095,7 +12095,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetAzureRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetAzureRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12131,7 +12131,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetConsulConfigAccess()
         {
@@ -12167,7 +12167,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetConsulConfigAccessAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -12205,14 +12205,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetConsulCredsRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->GetConsulCredsRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->GetConsulCredsRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12247,7 +12247,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12255,7 +12255,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->GetConsulCredsRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->GetConsulCredsRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12291,14 +12291,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetConsulRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetConsulRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetConsulRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12333,7 +12333,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12341,7 +12341,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetConsulRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetConsulRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12377,14 +12377,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetConsulRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetConsulRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetConsulRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12419,7 +12419,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12427,7 +12427,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetConsulRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetConsulRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12463,7 +12463,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the secret at the specified location. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -12471,7 +12471,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetCubbyholePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetCubbyholePath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12510,7 +12510,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the secret at the specified location. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -12519,7 +12519,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetCubbyholePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetCubbyholePath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12559,7 +12559,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpConfig()
         {
@@ -12595,7 +12595,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetGcpConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -12633,14 +12633,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpKeyRoleset(string roleset)
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpKeyRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpKeyRoleset");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12675,7 +12675,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12683,7 +12683,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpKeyRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpKeyRoleset");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12719,14 +12719,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpRolesetName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpRolesetName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpRolesetName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12761,7 +12761,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12769,7 +12769,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpRolesetName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpRolesetName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12805,14 +12805,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpRolesetRolesetKey(string roleset)
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetKey");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12847,7 +12847,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12855,7 +12855,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetKey");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12891,14 +12891,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpRolesetRolesetToken(string roleset)
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetToken");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetToken");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12933,7 +12933,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12941,7 +12941,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetToken");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpRolesetRolesetToken");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12977,14 +12977,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpRolesets(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpRolesets");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpRolesets");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13019,7 +13019,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13027,7 +13027,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpRolesets");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpRolesets");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13063,14 +13063,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpStaticAccountName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13105,7 +13105,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13113,7 +13113,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13149,14 +13149,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpStaticAccountNameKey(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13191,7 +13191,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13199,7 +13199,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13235,14 +13235,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpStaticAccountNameToken(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameToken");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameToken");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13277,7 +13277,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13285,7 +13285,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameToken");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetGcpStaticAccountNameToken");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13321,14 +13321,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpStaticAccounts(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpStaticAccounts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpStaticAccounts");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13363,7 +13363,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13371,7 +13371,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpStaticAccounts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpStaticAccounts");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13407,14 +13407,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpTokenRoleset(string roleset)
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpTokenRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpTokenRoleset");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13449,7 +13449,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13457,7 +13457,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpTokenRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->GetGcpTokenRoleset");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13493,7 +13493,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the GCP KMS secrets engine 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpkmsConfig()
         {
@@ -13529,7 +13529,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the GCP KMS secrets engine 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetGcpkmsConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -13567,14 +13567,14 @@ namespace Vault.Api
         /// <summary>
         /// List named keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpkmsKeys(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpkmsKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpkmsKeys");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13609,7 +13609,7 @@ namespace Vault.Api
         /// <summary>
         /// List named keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13617,7 +13617,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpkmsKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetGcpkmsKeys");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13653,14 +13653,14 @@ namespace Vault.Api
         /// <summary>
         /// Configure the key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpkmsKeysConfigKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysConfigKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysConfigKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13695,7 +13695,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13703,7 +13703,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysConfigKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysConfigKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13739,14 +13739,14 @@ namespace Vault.Api
         /// <summary>
         /// Interact with crypto keys in Vault and Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpkmsKeysKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13781,7 +13781,7 @@ namespace Vault.Api
         /// <summary>
         /// Interact with crypto keys in Vault and Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13789,7 +13789,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsKeysKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13825,14 +13825,14 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the public key associated with the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key for which to get the public key. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetGcpkmsPubkeyKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsPubkeyKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsPubkeyKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13867,7 +13867,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the public key associated with the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key for which to get the public key. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13875,7 +13875,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsPubkeyKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->GetGcpkmsPubkeyKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13911,7 +13911,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetKubernetesConfig()
         {
@@ -13947,7 +13947,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetKubernetesConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -13985,14 +13985,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetKubernetesRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetKubernetesRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetKubernetesRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14027,7 +14027,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14035,7 +14035,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetKubernetesRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetKubernetesRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14071,14 +14071,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetKubernetesRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetKubernetesRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetKubernetesRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14113,7 +14113,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14121,7 +14121,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetKubernetesRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetKubernetesRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14157,7 +14157,7 @@ namespace Vault.Api
         /// <summary>
         /// Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -14165,7 +14165,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetKvPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetKvPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14204,7 +14204,7 @@ namespace Vault.Api
         /// <summary>
         /// Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -14213,7 +14213,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetKvPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetKvPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14253,7 +14253,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the  credentials that are used to manage Database Users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetMongodbatlasConfig()
         {
@@ -14289,7 +14289,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the  credentials that are used to manage Database Users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetMongodbatlasConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -14327,14 +14327,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate MongoDB Atlas Programmatic API from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetMongodbatlasCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14369,7 +14369,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate MongoDB Atlas Programmatic API from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14377,7 +14377,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14413,14 +14413,14 @@ namespace Vault.Api
         /// <summary>
         /// List the existing roles in this backend 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetMongodbatlasRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetMongodbatlasRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetMongodbatlasRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14455,7 +14455,7 @@ namespace Vault.Api
         /// <summary>
         /// List the existing roles in this backend 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14463,7 +14463,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetMongodbatlasRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetMongodbatlasRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14499,14 +14499,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles used to generate MongoDB Atlas Programmatic API Keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetMongodbatlasRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14541,7 +14541,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles used to generate MongoDB Atlas Programmatic API Keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14549,7 +14549,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetMongodbatlasRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14585,7 +14585,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetNomadConfigAccess()
         {
@@ -14621,7 +14621,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetNomadConfigAccessAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -14659,7 +14659,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated tokens 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetNomadConfigLease()
         {
@@ -14695,7 +14695,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated tokens 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetNomadConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -14733,14 +14733,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetNomadCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14775,7 +14775,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14783,7 +14783,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14819,14 +14819,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetNomadRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetNomadRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetNomadRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14861,7 +14861,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14869,7 +14869,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetNomadRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetNomadRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14905,14 +14905,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetNomadRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14947,7 +14947,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14955,7 +14955,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetNomadRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14991,7 +14991,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetOpenldapConfig()
         {
@@ -15027,7 +15027,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetOpenldapConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15065,14 +15065,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the dynamic role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetOpenldapCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15107,7 +15107,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the dynamic role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15115,7 +15115,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15151,14 +15151,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetOpenldapRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15193,7 +15193,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15201,7 +15201,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15237,14 +15237,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetOpenldapRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15279,7 +15279,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15287,7 +15287,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15323,14 +15323,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetOpenldapStaticCredName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticCredName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticCredName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15365,7 +15365,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15373,7 +15373,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticCredName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticCredName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15409,14 +15409,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetOpenldapStaticRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapStaticRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapStaticRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15451,7 +15451,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15459,7 +15459,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapStaticRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetOpenldapStaticRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15495,14 +15495,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetOpenldapStaticRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15537,7 +15537,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15545,7 +15545,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetOpenldapStaticRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15581,7 +15581,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCa()
         {
@@ -15617,7 +15617,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCaAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15655,7 +15655,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCaChain()
         {
@@ -15691,7 +15691,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCaChainAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15729,7 +15729,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCaPem()
         {
@@ -15765,7 +15765,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCaPemAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15803,7 +15803,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCertCaChain()
         {
@@ -15839,7 +15839,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCertCaChainAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15877,7 +15877,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCertCrl()
         {
@@ -15913,7 +15913,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCertCrlAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15951,14 +15951,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCertSerial(string serial)
         {
             // verify the required parameter 'serial' is set
             if (serial == null)
-                throw new ApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerial");
+                throw new VaultApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerial");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15993,7 +15993,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16001,7 +16001,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'serial' is set
             if (serial == null)
-                throw new ApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerial");
+                throw new VaultApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerial");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16037,14 +16037,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCertSerialRaw(string serial)
         {
             // verify the required parameter 'serial' is set
             if (serial == null)
-                throw new ApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRaw");
+                throw new VaultApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRaw");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16079,7 +16079,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16087,7 +16087,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'serial' is set
             if (serial == null)
-                throw new ApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRaw");
+                throw new VaultApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRaw");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16123,14 +16123,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCertSerialRawPem(string serial)
         {
             // verify the required parameter 'serial' is set
             if (serial == null)
-                throw new ApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRawPem");
+                throw new VaultApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRawPem");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16165,7 +16165,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="serial">Certificate serial number, in colon- or hyphen-separated octal</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16173,7 +16173,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'serial' is set
             if (serial == null)
-                throw new ApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRawPem");
+                throw new VaultApiException(400, "Missing required parameter 'serial' when calling Secrets->GetPkiCertSerialRawPem");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16209,14 +16209,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCerts(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiCerts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiCerts");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16251,7 +16251,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16259,7 +16259,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiCerts");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiCerts");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16295,7 +16295,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiConfigCrl()
         {
@@ -16331,7 +16331,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiConfigCrlAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16369,7 +16369,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiConfigIssuers()
         {
@@ -16405,7 +16405,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiConfigIssuersAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16443,7 +16443,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiConfigKeys()
         {
@@ -16479,7 +16479,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiConfigKeysAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16517,7 +16517,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiConfigUrls()
         {
@@ -16553,7 +16553,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiConfigUrlsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16591,7 +16591,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCrl()
         {
@@ -16627,7 +16627,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCrlAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16665,7 +16665,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCrlPem()
         {
@@ -16701,7 +16701,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCrlPemAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16739,7 +16739,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiCrlRotate()
         {
@@ -16775,7 +16775,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiCrlRotateAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16813,7 +16813,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiDer()
         {
@@ -16849,7 +16849,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiDerAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -16887,14 +16887,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiIssuerRefCrlPem(string issuerRef)
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefCrlPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefCrlPem");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16929,7 +16929,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16937,7 +16937,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefCrlPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefCrlPem");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16973,14 +16973,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiIssuerRefDerPem(string issuerRef)
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefDerPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefDerPem");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17015,7 +17015,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17023,7 +17023,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefDerPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->GetPkiIssuerRefDerPem");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17059,14 +17059,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiIssuers(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiIssuers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiIssuers");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17101,7 +17101,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17109,7 +17109,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiIssuers");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiIssuers");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17145,7 +17145,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiJson()
         {
@@ -17181,7 +17181,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiJsonAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -17219,14 +17219,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiKeyKeyRef(string keyRef)
         {
             // verify the required parameter 'keyRef' is set
             if (keyRef == null)
-                throw new ApiException(400, "Missing required parameter 'keyRef' when calling Secrets->GetPkiKeyKeyRef");
+                throw new VaultApiException(400, "Missing required parameter 'keyRef' when calling Secrets->GetPkiKeyKeyRef");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17261,7 +17261,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17269,7 +17269,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'keyRef' is set
             if (keyRef == null)
-                throw new ApiException(400, "Missing required parameter 'keyRef' when calling Secrets->GetPkiKeyKeyRef");
+                throw new VaultApiException(400, "Missing required parameter 'keyRef' when calling Secrets->GetPkiKeyKeyRef");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17305,14 +17305,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiKeys(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiKeys");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17347,7 +17347,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17355,7 +17355,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiKeys");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17391,14 +17391,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17433,7 +17433,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17441,7 +17441,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetPkiRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17477,14 +17477,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetPkiRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetPkiRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17519,7 +17519,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17527,7 +17527,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetPkiRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetPkiRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17563,7 +17563,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetPkiTidyStatus()
         {
@@ -17599,7 +17599,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetPkiTidyStatusAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -17637,7 +17637,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated credentials 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetRabbitmqConfigLease()
         {
@@ -17673,7 +17673,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated credentials 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetRabbitmqConfigLeaseAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -17711,14 +17711,14 @@ namespace Vault.Api
         /// <summary>
         /// Request RabbitMQ credentials for a certain role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetRabbitmqCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17753,7 +17753,7 @@ namespace Vault.Api
         /// <summary>
         /// Request RabbitMQ credentials for a certain role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17761,7 +17761,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17797,14 +17797,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetRabbitmqRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetRabbitmqRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetRabbitmqRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17839,7 +17839,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17847,7 +17847,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetRabbitmqRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetRabbitmqRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17883,14 +17883,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetRabbitmqRolesName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -17925,7 +17925,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -17933,7 +17933,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetRabbitmqRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -17969,7 +17969,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the backend level settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSecretConfig()
         {
@@ -18005,7 +18005,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the backend level settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSecretConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18043,14 +18043,14 @@ namespace Vault.Api
         /// <summary>
         /// Write, Patch, Read, and Delete data in the Key-Value Store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSecretDataPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretDataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretDataPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18085,7 +18085,7 @@ namespace Vault.Api
         /// <summary>
         /// Write, Patch, Read, and Delete data in the Key-Value Store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18093,7 +18093,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretDataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretDataPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18129,7 +18129,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures settings for the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -18137,7 +18137,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretMetadataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretMetadataPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18176,7 +18176,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures settings for the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -18185,7 +18185,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretMetadataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretMetadataPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18225,14 +18225,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the structure of a secret entry from the Key-Value store with the values removed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSecretSubkeysPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretSubkeysPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretSubkeysPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18267,7 +18267,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the structure of a secret entry from the Key-Value store with the values removed. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18275,7 +18275,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretSubkeysPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->GetSecretSubkeysPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18311,7 +18311,7 @@ namespace Vault.Api
         /// <summary>
         /// Set the SSH private key used for signing certificates. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSshConfigCa()
         {
@@ -18347,7 +18347,7 @@ namespace Vault.Api
         /// <summary>
         /// Set the SSH private key used for signing certificates. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSshConfigCaAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18385,7 +18385,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign zero address as default CIDR block for select roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSshConfigZeroaddress()
         {
@@ -18421,7 +18421,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign zero address as default CIDR block for select roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSshConfigZeroaddressAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18459,7 +18459,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the public key. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSshPublicKey()
         {
@@ -18495,7 +18495,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the public key. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSshPublicKeyAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18533,14 +18533,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSshRoles(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetSshRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetSshRoles");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18575,7 +18575,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18583,7 +18583,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetSshRoles");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetSshRoles");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18619,14 +18619,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSshRolesRole(string role)
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->GetSshRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->GetSshRolesRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18661,7 +18661,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18669,7 +18669,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->GetSshRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->GetSshRolesRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18705,7 +18705,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTerraformConfig()
         {
@@ -18741,7 +18741,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetTerraformConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -18779,14 +18779,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate a Terraform Cloud or Enterprise API token from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTerraformCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18821,7 +18821,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a Terraform Cloud or Enterprise API token from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18829,7 +18829,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18865,14 +18865,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTerraformRole(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetTerraformRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetTerraformRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18907,7 +18907,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -18915,7 +18915,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetTerraformRole");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetTerraformRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -18951,14 +18951,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTerraformRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -18993,7 +18993,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19001,7 +19001,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTerraformRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19037,14 +19037,14 @@ namespace Vault.Api
         /// <summary>
         /// Request time-based one-time use password or validate a password for a certain key . 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTotpCodeName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpCodeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpCodeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19079,7 +19079,7 @@ namespace Vault.Api
         /// <summary>
         /// Request time-based one-time use password or validate a password for a certain key . 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19087,7 +19087,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpCodeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpCodeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19123,14 +19123,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTotpKeys(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetTotpKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetTotpKeys");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19165,7 +19165,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19173,7 +19173,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetTotpKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetTotpKeys");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19209,14 +19209,14 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTotpKeysName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpKeysName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19251,7 +19251,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19259,7 +19259,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTotpKeysName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19295,14 +19295,14 @@ namespace Vault.Api
         /// <summary>
         /// Backup the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTransitBackupName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitBackupName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitBackupName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19337,7 +19337,7 @@ namespace Vault.Api
         /// <summary>
         /// Backup the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19345,7 +19345,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitBackupName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitBackupName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19381,7 +19381,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the size of the active cache 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTransitCacheConfig()
         {
@@ -19417,7 +19417,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the size of the active cache 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetTransitCacheConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -19455,7 +19455,7 @@ namespace Vault.Api
         /// <summary>
         /// Export named encryption or signing key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19463,11 +19463,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19503,7 +19503,7 @@ namespace Vault.Api
         /// <summary>
         /// Export named encryption or signing key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -19512,11 +19512,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19553,7 +19553,7 @@ namespace Vault.Api
         /// <summary>
         /// Export named encryption or signing key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <param name="version">Version of the key</param>
@@ -19562,15 +19562,15 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeNameVersion");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeNameVersion");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeNameVersion");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeNameVersion");
 
             // verify the required parameter 'version' is set
             if (version == null)
-                throw new ApiException(400, "Missing required parameter 'version' when calling Secrets->GetTransitExportTypeNameVersion");
+                throw new VaultApiException(400, "Missing required parameter 'version' when calling Secrets->GetTransitExportTypeNameVersion");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19607,7 +19607,7 @@ namespace Vault.Api
         /// <summary>
         /// Export named encryption or signing key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="type">Type of key to export (encryption-key, signing-key, hmac-key)</param>
         /// <param name="version">Version of the key</param>
@@ -19617,15 +19617,15 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeNameVersion");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitExportTypeNameVersion");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeNameVersion");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling Secrets->GetTransitExportTypeNameVersion");
 
             // verify the required parameter 'version' is set
             if (version == null)
-                throw new ApiException(400, "Missing required parameter 'version' when calling Secrets->GetTransitExportTypeNameVersion");
+                throw new VaultApiException(400, "Missing required parameter 'version' when calling Secrets->GetTransitExportTypeNameVersion");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19663,14 +19663,14 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTransitKeys(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetTransitKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetTransitKeys");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19705,7 +19705,7 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19713,7 +19713,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling Secrets->GetTransitKeys");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling Secrets->GetTransitKeys");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19749,14 +19749,14 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTransitKeysName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitKeysName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -19791,7 +19791,7 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19799,7 +19799,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->GetTransitKeysName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -19835,7 +19835,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the public key to use for wrapping imported keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetTransitWrappingKey()
         {
@@ -19871,7 +19871,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the public key to use for wrapping imported keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetTransitWrappingKeyAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -19909,7 +19909,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the AD server to connect to, along with password options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="adConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAdConfig(AdConfigRequest adConfigRequest = default(AdConfigRequest))
@@ -19948,7 +19948,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the AD server to connect to, along with password options. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="adConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -19989,7 +19989,7 @@ namespace Vault.Api
         /// <summary>
         /// Check service accounts in to the library. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryManageCheckInRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -19997,7 +19997,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryManageNameCheckIn");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryManageNameCheckIn");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20034,7 +20034,7 @@ namespace Vault.Api
         /// <summary>
         /// Check service accounts in to the library. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryManageCheckInRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20043,7 +20043,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryManageNameCheckIn");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryManageNameCheckIn");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20081,7 +20081,7 @@ namespace Vault.Api
         /// <summary>
         /// Update a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20089,7 +20089,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20126,7 +20126,7 @@ namespace Vault.Api
         /// <summary>
         /// Update a library set. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20135,7 +20135,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20173,7 +20173,7 @@ namespace Vault.Api
         /// <summary>
         /// Check service accounts in to the library. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryCheckInRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20181,7 +20181,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckIn");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckIn");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20218,7 +20218,7 @@ namespace Vault.Api
         /// <summary>
         /// Check service accounts in to the library. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set.</param>
         /// <param name="adLibraryCheckInRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20227,7 +20227,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckIn");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckIn");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20265,7 +20265,7 @@ namespace Vault.Api
         /// <summary>
         /// Check a service account out from the library. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set</param>
         /// <param name="adLibraryCheckOutRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20273,7 +20273,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckOut");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckOut");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20310,7 +20310,7 @@ namespace Vault.Api
         /// <summary>
         /// Check a service account out from the library. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the set</param>
         /// <param name="adLibraryCheckOutRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20319,7 +20319,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckOut");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdLibraryNameCheckOut");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20357,7 +20357,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage roles to build links between Vault and Active Directory service accounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="adRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20365,7 +20365,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20402,7 +20402,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage roles to build links between Vault and Active Directory service accounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="adRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20411,7 +20411,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20449,14 +20449,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAdRotateRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRotateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRotateRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20491,7 +20491,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -20499,7 +20499,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRotateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAdRotateRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20535,7 +20535,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAdRotateRoot()
         {
@@ -20571,7 +20571,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAdRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -20609,7 +20609,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the access key and secret to use for RAM and STS calls. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAlicloudConfig(AlicloudConfigRequest alicloudConfigRequest = default(AlicloudConfigRequest))
@@ -20648,7 +20648,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the access key and secret to use for RAM and STS calls. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="alicloudConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -20689,7 +20689,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference policies and roles that API keys or STS credentials can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -20697,7 +20697,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAlicloudRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAlicloudRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -20734,7 +20734,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference policies and roles that API keys or STS credentials can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the role.</param>
         /// <param name="alicloudRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -20743,7 +20743,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAlicloudRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAlicloudRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -20781,7 +20781,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the default lease information for generated credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAwsConfigLease(AwsConfigLeaseRequest awsConfigLeaseRequest = default(AwsConfigLeaseRequest))
@@ -20820,7 +20820,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the default lease information for generated credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -20861,7 +20861,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the root credentials that are used to manage IAM. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigRootRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAwsConfigRoot(AwsConfigRootRequest awsConfigRootRequest = default(AwsConfigRootRequest))
@@ -20900,7 +20900,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the root credentials that are used to manage IAM. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsConfigRootRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -20941,7 +20941,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAwsConfigRotateRoot()
         {
@@ -20977,7 +20977,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAwsConfigRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -21015,7 +21015,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsCredsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAwsCreds(AwsCredsRequest awsCredsRequest = default(AwsCredsRequest))
@@ -21054,7 +21054,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="awsCredsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21095,7 +21095,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference IAM policies that access keys can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="awsRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21103,7 +21103,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21140,7 +21140,7 @@ namespace Vault.Api
         /// <summary>
         /// Read, write and reference IAM policies that access keys can be made for. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="awsRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21149,7 +21149,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21187,7 +21187,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="awsStsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21195,7 +21195,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsStsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsStsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21232,7 +21232,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate AWS credentials from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="awsStsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21241,7 +21241,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsStsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAwsStsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21279,7 +21279,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAzureConfig(AzureConfigRequest azureConfigRequest = default(AzureConfigRequest))
@@ -21318,7 +21318,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="azureConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21359,7 +21359,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the Vault roles used to generate Azure credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21367,7 +21367,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAzureRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAzureRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21404,7 +21404,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the Vault roles used to generate Azure credentials. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="azureRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21413,7 +21413,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostAzureRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostAzureRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21451,7 +21451,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostAzureRotateRoot()
         {
@@ -21487,7 +21487,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostAzureRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -21525,7 +21525,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="consulConfigAccessRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostConsulConfigAccess(ConsulConfigAccessRequest consulConfigAccessRequest = default(ConsulConfigAccessRequest))
@@ -21564,7 +21564,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="consulConfigAccessRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21605,7 +21605,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="consulRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21613,7 +21613,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostConsulRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostConsulRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21650,7 +21650,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="consulRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21659,7 +21659,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostConsulRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostConsulRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21697,14 +21697,14 @@ namespace Vault.Api
         /// <summary>
         /// Store a secret at the specified location. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostCubbyholePath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostCubbyholePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostCubbyholePath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21739,7 +21739,7 @@ namespace Vault.Api
         /// <summary>
         /// Store a secret at the specified location. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Specifies the path of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21747,7 +21747,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostCubbyholePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostCubbyholePath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -21783,7 +21783,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpConfig(GcpConfigRequest gcpConfigRequest = default(GcpConfigRequest))
@@ -21822,7 +21822,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -21863,7 +21863,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpConfigRotateRoot()
         {
@@ -21899,7 +21899,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostGcpConfigRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -21937,7 +21937,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -21945,7 +21945,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpKeyRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpKeyRoleset");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -21982,7 +21982,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -21991,7 +21991,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpKeyRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpKeyRoleset");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22029,7 +22029,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="gcpRolesetRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -22037,7 +22037,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22074,7 +22074,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the role.</param>
         /// <param name="gcpRolesetRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -22083,7 +22083,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22121,14 +22121,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpRolesetNameRotate(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotate");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22163,7 +22163,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22171,7 +22171,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotate");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22207,14 +22207,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpRolesetNameRotateKey(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotateKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotateKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22249,7 +22249,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22257,7 +22257,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotateKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpRolesetNameRotateKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22293,7 +22293,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpRolesetKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -22301,7 +22301,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetKey");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22338,7 +22338,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="gcpRolesetKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -22347,7 +22347,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetKey");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22385,14 +22385,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpRolesetRolesetToken(string roleset)
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetToken");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetToken");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22427,7 +22427,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22435,7 +22435,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetToken");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpRolesetRolesetToken");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22471,7 +22471,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="gcpStaticAccountRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -22479,7 +22479,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22516,7 +22516,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name to refer to this static account in Vault. Cannot be updated.</param>
         /// <param name="gcpStaticAccountRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -22525,7 +22525,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22563,7 +22563,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="gcpStaticAccountKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -22571,7 +22571,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22608,7 +22608,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="gcpStaticAccountKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -22617,7 +22617,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22655,14 +22655,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpStaticAccountNameRotateKey(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameRotateKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameRotateKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22697,7 +22697,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22705,7 +22705,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameRotateKey");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameRotateKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22741,14 +22741,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpStaticAccountNameToken(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameToken");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameToken");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22783,7 +22783,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Required. Name of the static account.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22791,7 +22791,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameToken");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostGcpStaticAccountNameToken");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22827,14 +22827,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpTokenRoleset(string roleset)
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpTokenRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpTokenRoleset");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -22869,7 +22869,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="roleset">Required. Name of the role set.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22877,7 +22877,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'roleset' is set
             if (roleset == null)
-                throw new ApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpTokenRoleset");
+                throw new VaultApiException(400, "Missing required parameter 'roleset' when calling Secrets->PostGcpTokenRoleset");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -22913,7 +22913,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the GCP KMS secrets engine 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpkmsConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpkmsConfig(GcpkmsConfigRequest gcpkmsConfigRequest = default(GcpkmsConfigRequest))
@@ -22952,7 +22952,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the GCP KMS secrets engine 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="gcpkmsConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -22993,7 +22993,7 @@ namespace Vault.Api
         /// <summary>
         /// Decrypt a ciphertext value using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for decryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsDecryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23001,7 +23001,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsDecryptKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsDecryptKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23038,7 +23038,7 @@ namespace Vault.Api
         /// <summary>
         /// Decrypt a ciphertext value using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for decryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsDecryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23047,7 +23047,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsDecryptKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsDecryptKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23085,7 +23085,7 @@ namespace Vault.Api
         /// <summary>
         /// Encrypt a plaintext value using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for encryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsEncryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23093,7 +23093,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsEncryptKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsEncryptKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23130,7 +23130,7 @@ namespace Vault.Api
         /// <summary>
         /// Encrypt a plaintext value using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for encryption. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsEncryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23139,7 +23139,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsEncryptKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsEncryptKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23177,7 +23177,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23185,7 +23185,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysConfigKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysConfigKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23222,7 +23222,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23231,7 +23231,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysConfigKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysConfigKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23269,14 +23269,14 @@ namespace Vault.Api
         /// <summary>
         /// Deregister an existing key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpkmsKeysDeregisterKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysDeregisterKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysDeregisterKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23311,7 +23311,7 @@ namespace Vault.Api
         /// <summary>
         /// Deregister an existing key in Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to deregister in Vault. If the key exists in Google Cloud KMS, it will be left untouched.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23319,7 +23319,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysDeregisterKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysDeregisterKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23355,7 +23355,7 @@ namespace Vault.Api
         /// <summary>
         /// Interact with crypto keys in Vault and Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23363,7 +23363,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23400,7 +23400,7 @@ namespace Vault.Api
         /// <summary>
         /// Interact with crypto keys in Vault and Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="gcpkmsKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23409,7 +23409,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23447,7 +23447,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an existing crypto key in Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to register in Vault. This will be the named used to refer to the underlying crypto key when encrypting or decrypting data.</param>
         /// <param name="gcpkmsKeysRegisterRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23455,7 +23455,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRegisterKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRegisterKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23492,7 +23492,7 @@ namespace Vault.Api
         /// <summary>
         /// Register an existing crypto key in Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to register in Vault. This will be the named used to refer to the underlying crypto key when encrypting or decrypting data.</param>
         /// <param name="gcpkmsKeysRegisterRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23501,7 +23501,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRegisterKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRegisterKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23539,14 +23539,14 @@ namespace Vault.Api
         /// <summary>
         /// Rotate a crypto key to a new primary version 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to rotate. This key must already be registered with Vault and point to a valid Google Cloud KMS crypto key.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpkmsKeysRotateKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRotateKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRotateKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23581,7 +23581,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotate a crypto key to a new primary version 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to rotate. This key must already be registered with Vault and point to a valid Google Cloud KMS crypto key.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23589,7 +23589,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRotateKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysRotateKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23625,14 +23625,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete old crypto key versions from Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostGcpkmsKeysTrimKey(string key)
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysTrimKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysTrimKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23667,7 +23667,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete old crypto key versions from Google Cloud KMS 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -23675,7 +23675,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysTrimKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsKeysTrimKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23711,7 +23711,7 @@ namespace Vault.Api
         /// <summary>
         /// Re-encrypt existing ciphertext data to a new version 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to use for encryption. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <param name="gcpkmsReencryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23719,7 +23719,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsReencryptKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsReencryptKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23756,7 +23756,7 @@ namespace Vault.Api
         /// <summary>
         /// Re-encrypt existing ciphertext data to a new version 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key to use for encryption. This key must already exist in Vault and Google Cloud KMS.</param>
         /// <param name="gcpkmsReencryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23765,7 +23765,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsReencryptKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsReencryptKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23803,7 +23803,7 @@ namespace Vault.Api
         /// <summary>
         /// Signs a message or digest using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for signing. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23811,7 +23811,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsSignKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsSignKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23848,7 +23848,7 @@ namespace Vault.Api
         /// <summary>
         /// Signs a message or digest using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for signing. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23857,7 +23857,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsSignKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsSignKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23895,7 +23895,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify a signature using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for verification. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -23903,7 +23903,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsVerifyKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsVerifyKey");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -23940,7 +23940,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify a signature using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="key">Name of the key in Vault to use for verification. This key must already exist in Vault and must map back to a Google Cloud KMS key.</param>
         /// <param name="gcpkmsVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -23949,7 +23949,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'key' is set
             if (key == null)
-                throw new ApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsVerifyKey");
+                throw new VaultApiException(400, "Missing required parameter 'key' when calling Secrets->PostGcpkmsVerifyKey");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -23987,7 +23987,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostKubernetesConfig(KubernetesConfigRequest kubernetesConfigRequest = default(KubernetesConfigRequest))
@@ -24026,7 +24026,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kubernetesConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24067,7 +24067,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Vault role</param>
         /// <param name="kubernetesCredsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24075,7 +24075,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24112,7 +24112,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Vault role</param>
         /// <param name="kubernetesCredsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24121,7 +24121,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24159,7 +24159,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="kubernetesRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24167,7 +24167,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24204,7 +24204,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="kubernetesRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24213,7 +24213,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostKubernetesRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24251,14 +24251,14 @@ namespace Vault.Api
         /// <summary>
         /// Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostKvPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostKvPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostKvPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24293,7 +24293,7 @@ namespace Vault.Api
         /// <summary>
         /// Pass-through secret storage to the storage backend, allowing you to read/write arbitrary data into secret storage. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24301,7 +24301,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostKvPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostKvPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24337,7 +24337,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the  credentials that are used to manage Database Users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="mongodbatlasConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostMongodbatlasConfig(MongodbatlasConfigRequest mongodbatlasConfigRequest = default(MongodbatlasConfigRequest))
@@ -24376,7 +24376,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the  credentials that are used to manage Database Users. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="mongodbatlasConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24417,14 +24417,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate MongoDB Atlas Programmatic API from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostMongodbatlasCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24459,7 +24459,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate MongoDB Atlas Programmatic API from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24467,7 +24467,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24503,7 +24503,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles used to generate MongoDB Atlas Programmatic API Keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="mongodbatlasRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24511,7 +24511,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24548,7 +24548,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles used to generate MongoDB Atlas Programmatic API Keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the Roles</param>
         /// <param name="mongodbatlasRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24557,7 +24557,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostMongodbatlasRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24595,7 +24595,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigAccessRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostNomadConfigAccess(NomadConfigAccessRequest nomadConfigAccessRequest = default(NomadConfigAccessRequest))
@@ -24634,7 +24634,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigAccessRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24675,7 +24675,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated tokens 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostNomadConfigLease(NomadConfigLeaseRequest nomadConfigLeaseRequest = default(NomadConfigLeaseRequest))
@@ -24714,7 +24714,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated tokens 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="nomadConfigLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24755,7 +24755,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="nomadRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24763,7 +24763,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostNomadRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostNomadRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24800,7 +24800,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="nomadRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24809,7 +24809,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostNomadRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostNomadRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -24847,7 +24847,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="openldapConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostOpenldapConfig(OpenldapConfigRequest openldapConfigRequest = default(OpenldapConfigRequest))
@@ -24886,7 +24886,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="openldapConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -24927,7 +24927,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="openldapRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -24935,7 +24935,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -24972,7 +24972,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role (lowercase)</param>
         /// <param name="openldapRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -24981,7 +24981,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25019,14 +25019,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostOpenldapRotateRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRotateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRotateRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25061,7 +25061,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the static role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25069,7 +25069,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRotateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapRotateRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25105,7 +25105,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostOpenldapRotateRoot()
         {
@@ -25141,7 +25141,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostOpenldapRotateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -25179,7 +25179,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="openldapStaticRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -25187,7 +25187,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapStaticRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapStaticRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25224,7 +25224,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="openldapStaticRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25233,7 +25233,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapStaticRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostOpenldapStaticRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -25271,7 +25271,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiBundleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiBundle(PkiBundleRequest pkiBundleRequest = default(PkiBundleRequest))
@@ -25310,7 +25310,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiBundleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25351,7 +25351,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiCertRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiCert(PkiCertRequest pkiCertRequest = default(PkiCertRequest))
@@ -25390,7 +25390,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiCertRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25431,7 +25431,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiConfigCa(PkiConfigCaRequest pkiConfigCaRequest = default(PkiConfigCaRequest))
@@ -25470,7 +25470,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25511,7 +25511,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCrlRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiConfigCrl(PkiConfigCrlRequest pkiConfigCrlRequest = default(PkiConfigCrlRequest))
@@ -25550,7 +25550,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigCrlRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25591,7 +25591,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigIssuersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiConfigIssuers(PkiConfigIssuersRequest pkiConfigIssuersRequest = default(PkiConfigIssuersRequest))
@@ -25630,7 +25630,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigIssuersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25671,7 +25671,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiConfigKeys(PkiConfigKeysRequest pkiConfigKeysRequest = default(PkiConfigKeysRequest))
@@ -25710,7 +25710,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25751,7 +25751,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigUrlsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiConfigUrls(PkiConfigUrlsRequest pkiConfigUrlsRequest = default(PkiConfigUrlsRequest))
@@ -25790,7 +25790,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiConfigUrlsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25831,7 +25831,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateCrossSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiIntermediateCrossSign(PkiIntermediateCrossSignRequest pkiIntermediateCrossSignRequest = default(PkiIntermediateCrossSignRequest))
@@ -25870,7 +25870,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateCrossSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -25911,7 +25911,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIntermediateGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -25919,7 +25919,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIntermediateGenerateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIntermediateGenerateExported");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -25956,7 +25956,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIntermediateGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -25965,7 +25965,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIntermediateGenerateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIntermediateGenerateExported");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26003,7 +26003,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateSetSignedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiIntermediateSetSigned(PkiIntermediateSetSignedRequest pkiIntermediateSetSignedRequest = default(PkiIntermediateSetSignedRequest))
@@ -26042,7 +26042,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiIntermediateSetSignedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26083,7 +26083,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiInternalExportedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiInternalExported(PkiInternalExportedRequest pkiInternalExportedRequest = default(PkiInternalExportedRequest))
@@ -26122,7 +26122,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiInternalExportedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -26163,7 +26163,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssueRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26171,7 +26171,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssueRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssueRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26208,7 +26208,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssueRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26217,7 +26217,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssueRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssueRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26255,7 +26255,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerIssueRequest"> (optional)</param>
@@ -26264,11 +26264,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
 
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26306,7 +26306,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerIssueRequest"> (optional)</param>
@@ -26316,11 +26316,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
 
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefIssueRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26359,7 +26359,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignIntermediateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26367,7 +26367,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignIntermediate");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignIntermediate");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26404,7 +26404,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignIntermediateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26413,7 +26413,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignIntermediate");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignIntermediate");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26451,7 +26451,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignRequest"> (optional)</param>
@@ -26460,11 +26460,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
 
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26502,7 +26502,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignRequest"> (optional)</param>
@@ -26512,11 +26512,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
 
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26555,7 +26555,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignSelfIssuedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26563,7 +26563,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignSelfIssued");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignSelfIssued");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26600,7 +26600,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignSelfIssuedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26609,7 +26609,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignSelfIssued");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignSelfIssued");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26647,7 +26647,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26655,7 +26655,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatim");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatim");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26692,7 +26692,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26701,7 +26701,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatim");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatim");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26739,7 +26739,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
@@ -26748,11 +26748,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
 
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26790,7 +26790,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiIssuerSignVerbatimRequest"> (optional)</param>
@@ -26800,11 +26800,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
 
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiIssuerIssuerRefSignVerbatimRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26843,7 +26843,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiDerPemRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26851,7 +26851,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerRefDerPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerRefDerPem");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26888,7 +26888,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="issuerRef">Reference to a existing issuer; either \&quot;default\&quot; for the configured default issuer, an identifier or the name assigned to the issuer.</param>
         /// <param name="pkiDerPemRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26897,7 +26897,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'issuerRef' is set
             if (issuerRef == null)
-                throw new ApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerRefDerPem");
+                throw new VaultApiException(400, "Missing required parameter 'issuerRef' when calling Secrets->PostPkiIssuerRefDerPem");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -26935,7 +26935,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateIntermediateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -26943,7 +26943,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateIntermediateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateIntermediateExported");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -26980,7 +26980,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateIntermediateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -26989,7 +26989,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateIntermediateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateIntermediateExported");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27027,7 +27027,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateRootRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -27035,7 +27035,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateRootExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateRootExported");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27072,7 +27072,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiIssuersGenerateRootRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27081,7 +27081,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateRootExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiIssuersGenerateRootExported");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27119,7 +27119,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiJsonRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiJson(PkiJsonRequest pkiJsonRequest = default(PkiJsonRequest))
@@ -27158,7 +27158,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiJsonRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27199,7 +27199,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="pkiKeyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -27207,7 +27207,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'keyRef' is set
             if (keyRef == null)
-                throw new ApiException(400, "Missing required parameter 'keyRef' when calling Secrets->PostPkiKeyKeyRef");
+                throw new VaultApiException(400, "Missing required parameter 'keyRef' when calling Secrets->PostPkiKeyKeyRef");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27244,7 +27244,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyRef">Reference to key; either \&quot;default\&quot; for the configured default key, an identifier of a key, or the name assigned to the key.</param>
         /// <param name="pkiKeyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27253,7 +27253,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'keyRef' is set
             if (keyRef == null)
-                throw new ApiException(400, "Missing required parameter 'keyRef' when calling Secrets->PostPkiKeyKeyRef");
+                throw new VaultApiException(400, "Missing required parameter 'keyRef' when calling Secrets->PostPkiKeyKeyRef");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27291,7 +27291,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKeysImportRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiKeysImport(PkiKeysImportRequest pkiKeysImportRequest = default(PkiKeysImportRequest))
@@ -27330,7 +27330,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKeysImportRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27371,7 +27371,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKmsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiKms(PkiKmsRequest pkiKmsRequest = default(PkiKmsRequest))
@@ -27410,7 +27410,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiKmsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27451,7 +27451,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiRevoke(PkiRevokeRequest pkiRevokeRequest = default(PkiRevokeRequest))
@@ -27490,7 +27490,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27531,7 +27531,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="pkiRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -27539,7 +27539,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostPkiRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostPkiRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27576,7 +27576,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="pkiRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27585,7 +27585,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostPkiRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostPkiRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27623,7 +27623,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootGenerateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -27631,7 +27631,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootGenerateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootGenerateExported");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27668,7 +27668,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootGenerateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27677,7 +27677,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootGenerateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootGenerateExported");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27715,7 +27715,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootReplaceRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiRootReplace(PkiRootReplaceRequest pkiRootReplaceRequest = default(PkiRootReplaceRequest))
@@ -27754,7 +27754,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootReplaceRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27795,7 +27795,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootRotateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -27803,7 +27803,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootRotateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootRotateExported");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -27840,7 +27840,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="exported">Must be \&quot;internal\&quot;, \&quot;exported\&quot; or \&quot;kms\&quot;. If set to \&quot;exported\&quot;, the generated private key will be returned. This is your *only* chance to retrieve the private key!</param>
         /// <param name="pkiRootRotateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -27849,7 +27849,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'exported' is set
             if (exported == null)
-                throw new ApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootRotateExported");
+                throw new VaultApiException(400, "Missing required parameter 'exported' when calling Secrets->PostPkiRootRotateExported");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -27887,7 +27887,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignIntermediateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiRootSignIntermediate(PkiRootSignIntermediateRequest pkiRootSignIntermediateRequest = default(PkiRootSignIntermediateRequest))
@@ -27926,7 +27926,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignIntermediateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -27967,7 +27967,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignSelfIssuedRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiRootSignSelfIssued(PkiRootSignSelfIssuedRequest pkiRootSignSelfIssuedRequest = default(PkiRootSignSelfIssuedRequest))
@@ -28006,7 +28006,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiRootSignSelfIssuedRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28047,7 +28047,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28055,7 +28055,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28092,7 +28092,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28101,7 +28101,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28139,7 +28139,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiSignVerbatim(PkiSignVerbatimRequest pkiSignVerbatimRequest = default(PkiSignVerbatimRequest))
@@ -28178,7 +28178,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28219,7 +28219,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28227,7 +28227,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignVerbatimRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignVerbatimRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28264,7 +28264,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request</param>
         /// <param name="pkiSignVerbatimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28273,7 +28273,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignVerbatimRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostPkiSignVerbatimRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28311,7 +28311,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiTidyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostPkiTidy(PkiTidyRequest pkiTidyRequest = default(PkiTidyRequest))
@@ -28350,7 +28350,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="pkiTidyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28391,7 +28391,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the connection URI, username, and password to talk to RabbitMQ management HTTP API. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigConnectionRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostRabbitmqConfigConnection(RabbitmqConfigConnectionRequest rabbitmqConfigConnectionRequest = default(RabbitmqConfigConnectionRequest))
@@ -28430,7 +28430,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the connection URI, username, and password to talk to RabbitMQ management HTTP API. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigConnectionRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28471,7 +28471,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated credentials 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostRabbitmqConfigLease(RabbitmqConfigLeaseRequest rabbitmqConfigLeaseRequest = default(RabbitmqConfigLeaseRequest))
@@ -28510,7 +28510,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the lease parameters for generated credentials 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="rabbitmqConfigLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28551,7 +28551,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="rabbitmqRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28559,7 +28559,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostRabbitmqRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostRabbitmqRolesName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28596,7 +28596,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the roles that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role.</param>
         /// <param name="rabbitmqRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28605,7 +28605,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostRabbitmqRolesName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostRabbitmqRolesName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28643,7 +28643,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure backend level settings that are applied to every key in the key-value store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kvConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSecretConfig(KvConfigRequest kvConfigRequest = default(KvConfigRequest))
@@ -28682,7 +28682,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure backend level settings that are applied to every key in the key-value store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="kvConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -28723,7 +28723,7 @@ namespace Vault.Api
         /// <summary>
         /// Write, Patch, Read, and Delete data in the Key-Value Store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDataRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28731,7 +28731,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDataPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28768,7 +28768,7 @@ namespace Vault.Api
         /// <summary>
         /// Write, Patch, Read, and Delete data in the Key-Value Store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDataRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28777,7 +28777,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDataPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28815,7 +28815,7 @@ namespace Vault.Api
         /// <summary>
         /// Marks one or more versions as deleted in the KV store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDeleteRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28823,7 +28823,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDeletePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDeletePath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28860,7 +28860,7 @@ namespace Vault.Api
         /// <summary>
         /// Marks one or more versions as deleted in the KV store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDeleteRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28869,7 +28869,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDeletePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDeletePath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28907,7 +28907,7 @@ namespace Vault.Api
         /// <summary>
         /// Permanently removes one or more versions in the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDestroyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -28915,7 +28915,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDestroyPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDestroyPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -28952,7 +28952,7 @@ namespace Vault.Api
         /// <summary>
         /// Permanently removes one or more versions in the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvDestroyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -28961,7 +28961,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDestroyPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretDestroyPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -28999,7 +28999,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures settings for the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvMetadataRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -29007,7 +29007,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretMetadataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretMetadataPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -29044,7 +29044,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures settings for the KV store 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvMetadataRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -29053,7 +29053,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretMetadataPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretMetadataPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -29091,7 +29091,7 @@ namespace Vault.Api
         /// <summary>
         /// Undeletes one or more versions from the KV store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvUndeleteRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -29099,7 +29099,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretUndeletePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretUndeletePath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -29136,7 +29136,7 @@ namespace Vault.Api
         /// <summary>
         /// Undeletes one or more versions from the KV store. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Location of the secret.</param>
         /// <param name="kvUndeleteRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -29145,7 +29145,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretUndeletePath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling Secrets->PostSecretUndeletePath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -29183,7 +29183,7 @@ namespace Vault.Api
         /// <summary>
         /// Set the SSH private key used for signing certificates. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigCaRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSshConfigCa(SshConfigCaRequest sshConfigCaRequest = default(SshConfigCaRequest))
@@ -29222,7 +29222,7 @@ namespace Vault.Api
         /// <summary>
         /// Set the SSH private key used for signing certificates. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigCaRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -29263,7 +29263,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign zero address as default CIDR block for select roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigZeroaddressRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSshConfigZeroaddress(SshConfigZeroaddressRequest sshConfigZeroaddressRequest = default(SshConfigZeroaddressRequest))
@@ -29302,7 +29302,7 @@ namespace Vault.Api
         /// <summary>
         /// Assign zero address as default CIDR block for select roles. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshConfigZeroaddressRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -29343,7 +29343,7 @@ namespace Vault.Api
         /// <summary>
         /// Creates a credential for establishing SSH connection with the remote host. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required] Name of the role</param>
         /// <param name="sshCredsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -29351,7 +29351,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshCredsRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshCredsRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -29388,7 +29388,7 @@ namespace Vault.Api
         /// <summary>
         /// Creates a credential for establishing SSH connection with the remote host. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required] Name of the role</param>
         /// <param name="sshCredsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -29397,7 +29397,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshCredsRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshCredsRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -29435,7 +29435,7 @@ namespace Vault.Api
         /// <summary>
         /// Register a shared private key with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <param name="sshKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -29443,7 +29443,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'keyName' is set
             if (keyName == null)
-                throw new ApiException(400, "Missing required parameter 'keyName' when calling Secrets->PostSshKeysKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'keyName' when calling Secrets->PostSshKeysKeyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -29480,7 +29480,7 @@ namespace Vault.Api
         /// <summary>
         /// Register a shared private key with Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="keyName">[Required] Name of the key</param>
         /// <param name="sshKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -29489,7 +29489,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'keyName' is set
             if (keyName == null)
-                throw new ApiException(400, "Missing required parameter 'keyName' when calling Secrets->PostSshKeysKeyName");
+                throw new VaultApiException(400, "Missing required parameter 'keyName' when calling Secrets->PostSshKeysKeyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -29527,7 +29527,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the roles associated with the given IP address. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSshLookup(SshLookupRequest sshLookupRequest = default(SshLookupRequest))
@@ -29566,7 +29566,7 @@ namespace Vault.Api
         /// <summary>
         /// List all the roles associated with the given IP address. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -29607,7 +29607,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="sshRolesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -29615,7 +29615,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshRolesRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -29652,7 +29652,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the &#39;roles&#39; that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">[Required for all types] Name of the role being created.</param>
         /// <param name="sshRolesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -29661,7 +29661,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshRolesRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshRolesRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -29699,7 +29699,7 @@ namespace Vault.Api
         /// <summary>
         /// Request signing an SSH key using a certain role with the provided details. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request.</param>
         /// <param name="sshSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -29707,7 +29707,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshSignRole");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -29744,7 +29744,7 @@ namespace Vault.Api
         /// <summary>
         /// Request signing an SSH key using a certain role with the provided details. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="role">The desired role with configuration for this request.</param>
         /// <param name="sshSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -29753,7 +29753,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'role' is set
             if (role == null)
-                throw new ApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshSignRole");
+                throw new VaultApiException(400, "Missing required parameter 'role' when calling Secrets->PostSshSignRole");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -29791,7 +29791,7 @@ namespace Vault.Api
         /// <summary>
         /// Validate the OTP provided by Vault SSH Agent. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSshVerify(SshVerifyRequest sshVerifyRequest = default(SshVerifyRequest))
@@ -29830,7 +29830,7 @@ namespace Vault.Api
         /// <summary>
         /// Validate the OTP provided by Vault SSH Agent. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="sshVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -29871,7 +29871,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="terraformConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTerraformConfig(TerraformConfigRequest terraformConfigRequest = default(TerraformConfigRequest))
@@ -29910,7 +29910,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="terraformConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -29951,14 +29951,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate a Terraform Cloud or Enterprise API token from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTerraformCredsName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformCredsName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -29993,7 +29993,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a Terraform Cloud or Enterprise API token from a specific Vault role. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -30001,7 +30001,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformCredsName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformCredsName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30037,7 +30037,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="terraformRoleRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -30045,7 +30045,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30082,7 +30082,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the role</param>
         /// <param name="terraformRoleRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -30091,7 +30091,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30129,14 +30129,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the team or organization role</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTerraformRotateRoleName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRotateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRotateRoleName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30171,7 +30171,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the team or organization role</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -30179,7 +30179,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRotateRoleName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTerraformRotateRoleName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30215,7 +30215,7 @@ namespace Vault.Api
         /// <summary>
         /// Request time-based one-time use password or validate a password for a certain key . 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpCodeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -30223,7 +30223,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpCodeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpCodeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30260,7 +30260,7 @@ namespace Vault.Api
         /// <summary>
         /// Request time-based one-time use password or validate a password for a certain key . 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpCodeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -30269,7 +30269,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpCodeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpCodeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30307,7 +30307,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -30315,7 +30315,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpKeysName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30352,7 +30352,7 @@ namespace Vault.Api
         /// <summary>
         /// Manage the keys that can be created with this backend. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key.</param>
         /// <param name="totpKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -30361,7 +30361,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTotpKeysName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30399,7 +30399,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures a new cache of the specified size 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitCacheConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTransitCacheConfig(TransitCacheConfigRequest transitCacheConfigRequest = default(TransitCacheConfigRequest))
@@ -30438,7 +30438,7 @@ namespace Vault.Api
         /// <summary>
         /// Configures a new cache of the specified size 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitCacheConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -30479,7 +30479,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a data key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The backend key used for encrypting the data key</param>
         /// <param name="plaintext">\&quot;plaintext\&quot; will return the key in both plaintext and ciphertext; \&quot;wrapped\&quot; will return the ciphertext only.</param>
         /// <param name="transitDatakeyRequest"> (optional)</param>
@@ -30488,11 +30488,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDatakeyPlaintextName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDatakeyPlaintextName");
 
             // verify the required parameter 'plaintext' is set
             if (plaintext == null)
-                throw new ApiException(400, "Missing required parameter 'plaintext' when calling Secrets->PostTransitDatakeyPlaintextName");
+                throw new VaultApiException(400, "Missing required parameter 'plaintext' when calling Secrets->PostTransitDatakeyPlaintextName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30530,7 +30530,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a data key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The backend key used for encrypting the data key</param>
         /// <param name="plaintext">\&quot;plaintext\&quot; will return the key in both plaintext and ciphertext; \&quot;wrapped\&quot; will return the ciphertext only.</param>
         /// <param name="transitDatakeyRequest"> (optional)</param>
@@ -30540,11 +30540,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDatakeyPlaintextName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDatakeyPlaintextName");
 
             // verify the required parameter 'plaintext' is set
             if (plaintext == null)
-                throw new ApiException(400, "Missing required parameter 'plaintext' when calling Secrets->PostTransitDatakeyPlaintextName");
+                throw new VaultApiException(400, "Missing required parameter 'plaintext' when calling Secrets->PostTransitDatakeyPlaintextName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30583,7 +30583,7 @@ namespace Vault.Api
         /// <summary>
         /// Decrypt a ciphertext value using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitDecryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -30591,7 +30591,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDecryptName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDecryptName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30628,7 +30628,7 @@ namespace Vault.Api
         /// <summary>
         /// Decrypt a ciphertext value using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitDecryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -30637,7 +30637,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDecryptName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitDecryptName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30675,7 +30675,7 @@ namespace Vault.Api
         /// <summary>
         /// Encrypt a plaintext value or a batch of plaintext blocks using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitEncryptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -30683,7 +30683,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitEncryptName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitEncryptName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30720,7 +30720,7 @@ namespace Vault.Api
         /// <summary>
         /// Encrypt a plaintext value or a batch of plaintext blocks using a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the policy</param>
         /// <param name="transitEncryptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -30729,7 +30729,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitEncryptName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitEncryptName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30767,7 +30767,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTransitHash(TransitHashRequest transitHashRequest = default(TransitHashRequest))
@@ -30806,7 +30806,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -30847,7 +30847,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -30855,7 +30855,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHashUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHashUrlalgorithm");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30892,7 +30892,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -30901,7 +30901,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHashUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHashUrlalgorithm");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -30939,7 +30939,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an HMAC for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="transitHmacRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -30947,7 +30947,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -30984,7 +30984,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an HMAC for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="transitHmacRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -30993,7 +30993,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31031,7 +31031,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an HMAC for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHmacRequest"> (optional)</param>
@@ -31040,11 +31040,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacNameUrlalgorithm");
 
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHmacNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHmacNameUrlalgorithm");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31082,7 +31082,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an HMAC for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use for the HMAC function</param>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="transitHmacRequest"> (optional)</param>
@@ -31092,11 +31092,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitHmacNameUrlalgorithm");
 
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHmacNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitHmacNameUrlalgorithm");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31135,7 +31135,7 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -31143,7 +31143,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31180,7 +31180,7 @@ namespace Vault.Api
         /// <summary>
         /// Managed named encryption keys 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -31189,7 +31189,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31227,7 +31227,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure a named encryption key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -31235,7 +31235,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameConfig");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameConfig");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31272,7 +31272,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure a named encryption key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -31281,7 +31281,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameConfig");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameConfig");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31319,7 +31319,7 @@ namespace Vault.Api
         /// <summary>
         /// Imports an externally-generated key into a new transit key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -31327,7 +31327,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImport");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImport");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31364,7 +31364,7 @@ namespace Vault.Api
         /// <summary>
         /// Imports an externally-generated key into a new transit key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -31373,7 +31373,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImport");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImport");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31411,7 +31411,7 @@ namespace Vault.Api
         /// <summary>
         /// Imports an externally-generated key into an existing imported key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportVersionRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -31419,7 +31419,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImportVersion");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImportVersion");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31456,7 +31456,7 @@ namespace Vault.Api
         /// <summary>
         /// Imports an externally-generated key into an existing imported key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the key</param>
         /// <param name="transitKeysImportVersionRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -31465,7 +31465,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImportVersion");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameImportVersion");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31503,14 +31503,14 @@ namespace Vault.Api
         /// <summary>
         /// Rotate named encryption key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTransitKeysNameRotate(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameRotate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameRotate");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31545,7 +31545,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotate named encryption key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -31553,7 +31553,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameRotate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameRotate");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31589,7 +31589,7 @@ namespace Vault.Api
         /// <summary>
         /// Trim key versions of a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysTrimRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -31597,7 +31597,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameTrim");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameTrim");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31634,7 +31634,7 @@ namespace Vault.Api
         /// <summary>
         /// Trim key versions of a named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitKeysTrimRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -31643,7 +31643,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameTrim");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitKeysNameTrim");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31681,7 +31681,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTransitRandom(TransitRandomRequest transitRandomRequest = default(TransitRandomRequest))
@@ -31720,7 +31720,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -31761,7 +31761,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -31769,7 +31769,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSource");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSource");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31806,7 +31806,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -31815,7 +31815,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSource");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSource");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31853,7 +31853,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
@@ -31862,11 +31862,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSourceUrlbytes");
 
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomSourceUrlbytes");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -31904,7 +31904,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
@@ -31914,11 +31914,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling Secrets->PostTransitRandomSourceUrlbytes");
 
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomSourceUrlbytes");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -31957,7 +31957,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -31965,7 +31965,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomUrlbytes");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -32002,7 +32002,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="transitRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -32011,7 +32011,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling Secrets->PostTransitRandomUrlbytes");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -32049,7 +32049,7 @@ namespace Vault.Api
         /// <summary>
         /// Restore the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostTransitRestore(TransitRestoreRequest transitRestoreRequest = default(TransitRestoreRequest))
@@ -32088,7 +32088,7 @@ namespace Vault.Api
         /// <summary>
         /// Restore the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -32129,7 +32129,7 @@ namespace Vault.Api
         /// <summary>
         /// Restore the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">If set, this will be the name of the restored key.</param>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -32137,7 +32137,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRestoreName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRestoreName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -32174,7 +32174,7 @@ namespace Vault.Api
         /// <summary>
         /// Restore the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">If set, this will be the name of the restored key.</param>
         /// <param name="transitRestoreRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -32183,7 +32183,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRestoreName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRestoreName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -32221,7 +32221,7 @@ namespace Vault.Api
         /// <summary>
         /// Rewrap ciphertext 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitRewrapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -32229,7 +32229,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRewrapName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRewrapName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -32266,7 +32266,7 @@ namespace Vault.Api
         /// <summary>
         /// Rewrap ciphertext 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the key</param>
         /// <param name="transitRewrapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -32275,7 +32275,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRewrapName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitRewrapName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -32313,7 +32313,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a signature for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitSignRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -32321,7 +32321,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -32358,7 +32358,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a signature for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitSignRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -32367,7 +32367,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -32405,7 +32405,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a signature for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitSignRequest"> (optional)</param>
@@ -32414,11 +32414,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignNameUrlalgorithm");
 
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitSignNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitSignNameUrlalgorithm");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -32456,7 +32456,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a signature for input data using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitSignRequest"> (optional)</param>
@@ -32466,11 +32466,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitSignNameUrlalgorithm");
 
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitSignNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitSignNameUrlalgorithm");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -32509,7 +32509,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify a signature or HMAC for input data created using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -32517,7 +32517,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -32554,7 +32554,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify a signature or HMAC for input data created using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -32563,7 +32563,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -32601,7 +32601,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify a signature or HMAC for input data created using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
@@ -32610,11 +32610,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
 
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -32652,7 +32652,7 @@ namespace Vault.Api
         /// <summary>
         /// Verify a signature or HMAC for input data created using the named key 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The key to use</param>
         /// <param name="urlalgorithm">Hash algorithm to use (POST URL parameter)</param>
         /// <param name="transitVerifyRequest"> (optional)</param>
@@ -32662,11 +32662,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
 
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling Secrets->PostTransitVerifyNameUrlalgorithm");
 
 
             RequestOptions requestOptions = new RequestOptions();

--- a/src/Vault/Api/System.cs
+++ b/src/Vault/Api/System.cs
@@ -29,7 +29,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysAuditPath(string path);
@@ -39,7 +39,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysAuthPath(string path);
@@ -49,7 +49,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysConfigAuditingRequestHeadersHeader(string header);
@@ -59,7 +59,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysConfigCors();
         /// <summary>
@@ -68,7 +68,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysConfigUiHeadersHeader(string header);
@@ -78,7 +78,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysGenerateRoot();
         /// <summary>
@@ -87,7 +87,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysGenerateRootAttempt();
         /// <summary>
@@ -96,7 +96,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysMountsPath(string path);
@@ -106,7 +106,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysPluginsCatalogName(string name);
@@ -116,7 +116,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -127,7 +127,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysPoliciesAclName(string name);
@@ -137,7 +137,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysPoliciesPasswordName(string name);
@@ -147,7 +147,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysPolicyName(string name);
@@ -157,7 +157,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysQuotasRateLimitName(string name);
@@ -167,7 +167,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysRaw();
         /// <summary>
@@ -176,7 +176,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysRawPath(string path);
@@ -186,7 +186,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysRekeyBackup();
         /// <summary>
@@ -195,7 +195,7 @@ namespace Vault.Api
         /// <remarks>
         /// This clears the rekey settings as well as any progress made. This must be called to change the parameters of the rekey. Note: verification is still a part of a rekey. If rekeying is canceled during the verification flow, the current unseal keys remain valid.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysRekeyInit();
         /// <summary>
@@ -204,7 +204,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysRekeyRecoveryKeyBackup();
         /// <summary>
@@ -213,7 +213,7 @@ namespace Vault.Api
         /// <remarks>
         /// This clears any progress made and resets the nonce. Unlike a &#x60;DELETE&#x60; against &#x60;sys/rekey/init&#x60;, this only resets the current verification operation, not the entire rekey atttempt.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> DeleteSysRekeyVerify();
         /// <summary>
@@ -222,7 +222,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysAudit();
         /// <summary>
@@ -231,7 +231,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysAuth();
         /// <summary>
@@ -240,7 +240,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysAuthPath(string path);
@@ -250,7 +250,7 @@ namespace Vault.Api
         /// <remarks>
         /// This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysAuthPathTune(string path);
@@ -260,7 +260,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysConfigAuditingRequestHeaders();
         /// <summary>
@@ -269,7 +269,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysConfigAuditingRequestHeadersHeader(string header);
@@ -279,7 +279,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysConfigCors();
         /// <summary>
@@ -288,7 +288,7 @@ namespace Vault.Api
         /// <remarks>
         /// The sanitized output strips configuration values in the storage, HA storage, and seals stanzas, which may contain sensitive values such as API tokens. It also removes any token or secret fields in other stanzas, such as the circonus_api_token from telemetry.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysConfigStateSanitized();
         /// <summary>
@@ -297,7 +297,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysConfigUiHeaders(string list);
@@ -307,7 +307,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysConfigUiHeadersHeader(string header);
@@ -317,7 +317,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysGenerateRoot();
         /// <summary>
@@ -326,7 +326,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysGenerateRootAttempt();
         /// <summary>
@@ -335,7 +335,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysHaStatus();
         /// <summary>
@@ -344,7 +344,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysHealth();
         /// <summary>
@@ -353,7 +353,7 @@ namespace Vault.Api
         /// <remarks>
         /// Information about the host instance that this Vault server is running on.   The information that gets collected includes host hardware information, and CPU,   disk, and memory utilization
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysHostInfo();
         /// <summary>
@@ -362,7 +362,7 @@ namespace Vault.Api
         /// <remarks>
         /// This path responds to the following HTTP methods.   GET /    Returns a map of in-flight requests.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInFlightReq();
         /// <summary>
@@ -371,7 +371,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInit();
         /// <summary>
@@ -380,7 +380,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalCountersActivity();
         /// <summary>
@@ -389,7 +389,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalCountersActivityExport();
         /// <summary>
@@ -398,7 +398,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalCountersActivityMonthly();
         /// <summary>
@@ -407,7 +407,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalCountersConfig();
         /// <summary>
@@ -416,7 +416,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalCountersEntities();
         /// <summary>
@@ -425,7 +425,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalCountersRequests();
         /// <summary>
@@ -434,7 +434,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalCountersTokens();
         /// <summary>
@@ -443,7 +443,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalSpecsOpenapi();
         /// <summary>
@@ -452,7 +452,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalUiFeatureFlags();
         /// <summary>
@@ -461,7 +461,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalUiMounts();
         /// <summary>
@@ -470,7 +470,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path of the mount.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalUiMountsPath(string path);
@@ -480,7 +480,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalUiNamespaces();
         /// <summary>
@@ -489,7 +489,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysInternalUiResultantAcl();
         /// <summary>
@@ -498,7 +498,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysKeyStatus();
         /// <summary>
@@ -507,7 +507,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysLeader();
         /// <summary>
@@ -516,7 +516,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysLeases();
         /// <summary>
@@ -525,7 +525,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysLeasesCount();
         /// <summary>
@@ -534,7 +534,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysLeasesLookup(string list);
@@ -544,7 +544,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to list leases under. Example: \&quot;aws/creds/deploy\&quot;</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -555,7 +555,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="format">Format to export metrics into. Currently accepts only \&quot;prometheus\&quot;. (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysMetrics(string format = default(string));
@@ -565,7 +565,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="logFormat">Output format of logs. Supported values are \&quot;standard\&quot; and \&quot;json\&quot;. The default is \&quot;standard\&quot;. (optional, default to &quot;standard&quot;)</param>
         /// <param name="logLevel">Log level to view system logs at. Currently supported values are \&quot;trace\&quot;, \&quot;debug\&quot;, \&quot;info\&quot;, \&quot;warn\&quot;, \&quot;error\&quot;. (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -576,7 +576,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysMounts();
         /// <summary>
@@ -585,7 +585,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysMountsPath(string path);
@@ -595,7 +595,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysMountsPathTune(string path);
@@ -605,7 +605,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPluginsCatalog();
         /// <summary>
@@ -614,7 +614,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPluginsCatalogName(string name);
@@ -624,7 +624,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -635,7 +635,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -646,7 +646,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPoliciesAcl(string list);
@@ -656,7 +656,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPoliciesAclName(string name);
@@ -666,7 +666,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPoliciesPassword(string list);
@@ -676,7 +676,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPoliciesPasswordName(string name);
@@ -686,7 +686,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPoliciesPasswordNameGenerate(string name);
@@ -696,7 +696,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPolicy(string list = default(string));
@@ -706,7 +706,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPolicyName(string name);
@@ -716,7 +716,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns an HTML page listing the available  profiles. This should be mainly accessed via browsers or applications that can  render pages.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprof();
         /// <summary>
@@ -725,7 +725,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns a sampling of all past memory allocations.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofAllocs();
         /// <summary>
@@ -734,7 +734,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces that led to blocking on synchronization primitives
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofBlock();
         /// <summary>
@@ -743,7 +743,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns the running program&#39;s command line, with arguments separated by NUL bytes.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofCmdline();
         /// <summary>
@@ -752,7 +752,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces of all current goroutines.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofGoroutine();
         /// <summary>
@@ -761,7 +761,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns a sampling of memory allocations of live object.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofHeap();
         /// <summary>
@@ -770,7 +770,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces of holders of contended mutexes
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofMutex();
         /// <summary>
@@ -779,7 +779,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns a pprof-formatted cpu profile payload. Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofProfile();
         /// <summary>
@@ -788,7 +788,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns the program counters listed in the request.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofSymbol();
         /// <summary>
@@ -797,7 +797,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces that led to the creation of new OS threads
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofThreadcreate();
         /// <summary>
@@ -806,7 +806,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns  the execution trace in binary form. Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysPprofTrace();
         /// <summary>
@@ -815,7 +815,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysQuotasConfig();
         /// <summary>
@@ -824,7 +824,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysQuotasRateLimit(string list);
@@ -834,7 +834,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysQuotasRateLimitName(string name);
@@ -844,7 +844,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysRaw(string list = default(string));
@@ -854,7 +854,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -865,7 +865,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysRekeyBackup();
         /// <summary>
@@ -874,7 +874,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysRekeyInit();
         /// <summary>
@@ -883,7 +883,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysRekeyRecoveryKeyBackup();
         /// <summary>
@@ -892,7 +892,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysRekeyVerify();
         /// <summary>
@@ -901,7 +901,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="migrationId">The ID of the migration operation</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysRemountStatusMigrationId(string migrationId);
@@ -911,7 +911,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysReplicationStatus();
         /// <summary>
@@ -920,7 +920,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysRotateConfig();
         /// <summary>
@@ -929,7 +929,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysSealStatus();
         /// <summary>
@@ -938,7 +938,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysVersionHistory(string list);
@@ -948,7 +948,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> GetSysWrappingLookup();
         /// <summary>
@@ -957,7 +957,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -968,7 +968,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -979,7 +979,7 @@ namespace Vault.Api
         /// <remarks>
         /// After enabling, the auth method can be accessed and configured via the auth path specified as part of the URL. This auth path will be nested under the auth prefix.  For example, enable the \&quot;foo\&quot; auth method will make it accessible at /auth/foo.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="systemAuthRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -990,7 +990,7 @@ namespace Vault.Api
         /// <remarks>
         /// This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <param name="systemAuthTuneRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1001,7 +1001,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysCapabilities(SystemCapabilitiesRequest systemCapabilitiesRequest = default(SystemCapabilitiesRequest));
@@ -1011,7 +1011,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysCapabilitiesAccessor(SystemCapabilitiesAccessorRequest systemCapabilitiesAccessorRequest = default(SystemCapabilitiesAccessorRequest));
@@ -1021,7 +1021,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesSelfRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysCapabilitiesSelf(SystemCapabilitiesSelfRequest systemCapabilitiesSelfRequest = default(SystemCapabilitiesSelfRequest));
@@ -1031,7 +1031,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="systemConfigAuditingRequestHeadersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1042,7 +1042,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemConfigCorsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysConfigCors(SystemConfigCorsRequest systemConfigCorsRequest = default(SystemConfigCorsRequest));
@@ -1052,7 +1052,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="subsystem"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysConfigReloadSubsystem(string subsystem);
@@ -1062,7 +1062,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="systemConfigUiHeadersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1073,7 +1073,7 @@ namespace Vault.Api
         /// <remarks>
         /// Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysGenerateRoot(SystemGenerateRootRequest systemGenerateRootRequest = default(SystemGenerateRootRequest));
@@ -1083,7 +1083,7 @@ namespace Vault.Api
         /// <remarks>
         /// Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootAttemptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysGenerateRootAttempt(SystemGenerateRootAttemptRequest systemGenerateRootAttemptRequest = default(SystemGenerateRootAttemptRequest));
@@ -1093,7 +1093,7 @@ namespace Vault.Api
         /// <remarks>
         /// If the threshold number of unseal key shares is reached, Vault will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootUpdateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysGenerateRootUpdate(SystemGenerateRootUpdateRequest systemGenerateRootUpdateRequest = default(SystemGenerateRootUpdateRequest));
@@ -1103,7 +1103,7 @@ namespace Vault.Api
         /// <remarks>
         /// The Vault must not have been previously initialized. The recovery options, as well as the stored shares option, are only available when using Vault HSM.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInitRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysInit(SystemInitRequest systemInitRequest = default(SystemInitRequest));
@@ -1113,7 +1113,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInternalCountersConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysInternalCountersConfig(SystemInternalCountersConfigRequest systemInternalCountersConfigRequest = default(SystemInternalCountersConfigRequest));
@@ -1123,7 +1123,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysLeasesLookup(SystemLeasesLookupRequest systemLeasesLookupRequest = default(SystemLeasesLookupRequest));
@@ -1133,7 +1133,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRenewRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysLeasesRenew(SystemLeasesRenewRequest systemLeasesRenewRequest = default(SystemLeasesRenewRequest));
@@ -1143,7 +1143,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRenewLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1154,7 +1154,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysLeasesRevoke(SystemLeasesRevokeRequest systemLeasesRevokeRequest = default(SystemLeasesRevokeRequest));
@@ -1164,7 +1164,7 @@ namespace Vault.Api
         /// <remarks>
         /// Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysLeasesRevokeForcePrefix(string prefix);
@@ -1174,7 +1174,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemLeasesRevokePrefixRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1185,7 +1185,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRevokeLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1196,7 +1196,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysLeasesTidy();
         /// <summary>
@@ -1205,7 +1205,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemMfaValidateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysMfaValidate(SystemMfaValidateRequest systemMfaValidateRequest = default(SystemMfaValidateRequest));
@@ -1215,7 +1215,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1226,7 +1226,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsTuneRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1237,7 +1237,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1248,7 +1248,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
@@ -1260,7 +1260,7 @@ namespace Vault.Api
         /// <remarks>
         /// Either the plugin name (&#x60;plugin&#x60;) or the desired plugin backend mounts (&#x60;mounts&#x60;) must be provided, but not both. In the case that the plugin name is provided, all mounted paths that use that plugin backend will be reloaded.  If (&#x60;scope&#x60;) is provided and is (&#x60;global&#x60;), the plugin(s) are reloaded globally.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemPluginsReloadBackendRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysPluginsReloadBackend(SystemPluginsReloadBackendRequest systemPluginsReloadBackendRequest = default(SystemPluginsReloadBackendRequest));
@@ -1270,7 +1270,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPoliciesAclRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1281,7 +1281,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="systemPoliciesPasswordRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1292,7 +1292,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPolicyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1303,7 +1303,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemQuotasConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysQuotasConfig(SystemQuotasConfigRequest systemQuotasConfigRequest = default(SystemQuotasConfigRequest));
@@ -1313,7 +1313,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="systemQuotasRateLimitRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1324,7 +1324,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRaw(SystemRawRequest systemRawRequest = default(SystemRawRequest));
@@ -1334,7 +1334,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1345,7 +1345,7 @@ namespace Vault.Api
         /// <remarks>
         /// Only a single rekey attempt can take place at a time, and changing the parameters of a rekey requires canceling and starting a new rekey, which will also provide a new nonce.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyInitRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRekeyInit(SystemRekeyInitRequest systemRekeyInitRequest = default(SystemRekeyInitRequest));
@@ -1355,7 +1355,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyUpdateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRekeyUpdate(SystemRekeyUpdateRequest systemRekeyUpdateRequest = default(SystemRekeyUpdateRequest));
@@ -1365,7 +1365,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRekeyVerify(SystemRekeyVerifyRequest systemRekeyVerifyRequest = default(SystemRekeyVerifyRequest));
@@ -1375,7 +1375,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRemountRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRemount(SystemRemountRequest systemRemountRequest = default(SystemRemountRequest));
@@ -1385,7 +1385,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRenewRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRenew(SystemRenewRequest systemRenewRequest = default(SystemRenewRequest));
@@ -1395,7 +1395,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRenewLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1406,7 +1406,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRevoke(SystemRevokeRequest systemRevokeRequest = default(SystemRevokeRequest));
@@ -1416,7 +1416,7 @@ namespace Vault.Api
         /// <remarks>
         /// Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRevokeForcePrefix(string prefix);
@@ -1426,7 +1426,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemRevokePrefixRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1437,7 +1437,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRevokeLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1448,7 +1448,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRotate();
         /// <summary>
@@ -1457,7 +1457,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRotateConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysRotateConfig(SystemRotateConfigRequest systemRotateConfigRequest = default(SystemRotateConfigRequest));
@@ -1467,7 +1467,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysSeal();
         /// <summary>
@@ -1476,7 +1476,7 @@ namespace Vault.Api
         /// <remarks>
         /// This endpoint forces the node to give up active status. If the node does not have active status, this endpoint does nothing. Note that the node will sleep for ten seconds before attempting to grab the active lock again, but if no standby nodes grab the active lock in the interim, the same node may become the active node again.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysStepDown();
         /// <summary>
@@ -1485,7 +1485,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysToolsHash(SystemToolsHashRequest systemToolsHashRequest = default(SystemToolsHashRequest));
@@ -1495,7 +1495,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1506,7 +1506,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysToolsRandom(SystemToolsRandomRequest systemToolsRandomRequest = default(SystemToolsRandomRequest));
@@ -1516,7 +1516,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1527,7 +1527,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
@@ -1539,7 +1539,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -1550,7 +1550,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemUnsealRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysUnseal(SystemUnsealRequest systemUnsealRequest = default(SystemUnsealRequest));
@@ -1560,7 +1560,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysWrappingLookup(SystemWrappingLookupRequest systemWrappingLookupRequest = default(SystemWrappingLookupRequest));
@@ -1570,7 +1570,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingRewrapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysWrappingRewrap(SystemWrappingRewrapRequest systemWrappingRewrapRequest = default(SystemWrappingRewrapRequest));
@@ -1580,7 +1580,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingUnwrapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysWrappingUnwrap(SystemWrappingUnwrapRequest systemWrappingUnwrapRequest = default(SystemWrappingUnwrapRequest));
@@ -1590,7 +1590,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> PostSysWrappingWrap();
         #endregion Synchronous Operations
@@ -1609,7 +1609,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1621,7 +1621,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1633,7 +1633,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1645,7 +1645,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysConfigCorsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1656,7 +1656,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1668,7 +1668,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysGenerateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1679,7 +1679,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysGenerateRootAttemptAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1690,7 +1690,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1702,7 +1702,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1714,7 +1714,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -1727,7 +1727,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1739,7 +1739,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1751,7 +1751,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1763,7 +1763,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1775,7 +1775,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysRawAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1786,7 +1786,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1798,7 +1798,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysRekeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1809,7 +1809,7 @@ namespace Vault.Api
         /// <remarks>
         /// This clears the rekey settings as well as any progress made. This must be called to change the parameters of the rekey. Note: verification is still a part of a rekey. If rekeying is canceled during the verification flow, the current unseal keys remain valid.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysRekeyInitAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1820,7 +1820,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysRekeyRecoveryKeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1831,7 +1831,7 @@ namespace Vault.Api
         /// <remarks>
         /// This clears any progress made and resets the nonce. Unlike a &#x60;DELETE&#x60; against &#x60;sys/rekey/init&#x60;, this only resets the current verification operation, not the entire rekey atttempt.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> DeleteSysRekeyVerifyAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1842,7 +1842,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysAuditAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1853,7 +1853,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysAuthAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1864,7 +1864,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1876,7 +1876,7 @@ namespace Vault.Api
         /// <remarks>
         /// This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1888,7 +1888,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysConfigAuditingRequestHeadersAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1899,7 +1899,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1911,7 +1911,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysConfigCorsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1922,7 +1922,7 @@ namespace Vault.Api
         /// <remarks>
         /// The sanitized output strips configuration values in the storage, HA storage, and seals stanzas, which may contain sensitive values such as API tokens. It also removes any token or secret fields in other stanzas, such as the circonus_api_token from telemetry.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysConfigStateSanitizedAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1933,7 +1933,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1945,7 +1945,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -1957,7 +1957,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysGenerateRootAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1968,7 +1968,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysGenerateRootAttemptAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1979,7 +1979,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysHaStatusAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -1990,7 +1990,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysHealthAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2001,7 +2001,7 @@ namespace Vault.Api
         /// <remarks>
         /// Information about the host instance that this Vault server is running on.   The information that gets collected includes host hardware information, and CPU,   disk, and memory utilization
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysHostInfoAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2012,7 +2012,7 @@ namespace Vault.Api
         /// <remarks>
         /// This path responds to the following HTTP methods.   GET /    Returns a map of in-flight requests.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInFlightReqAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2023,7 +2023,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInitAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2034,7 +2034,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalCountersActivityAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2045,7 +2045,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalCountersActivityExportAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2056,7 +2056,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalCountersActivityMonthlyAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2067,7 +2067,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalCountersConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2078,7 +2078,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalCountersEntitiesAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2089,7 +2089,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalCountersRequestsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2100,7 +2100,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalCountersTokensAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2111,7 +2111,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalSpecsOpenapiAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2122,7 +2122,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalUiFeatureFlagsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2133,7 +2133,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalUiMountsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2144,7 +2144,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path of the mount.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2156,7 +2156,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalUiNamespacesAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2167,7 +2167,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysInternalUiResultantAclAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2178,7 +2178,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysKeyStatusAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2189,7 +2189,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysLeaderAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2200,7 +2200,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysLeasesAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2211,7 +2211,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysLeasesCountAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2222,7 +2222,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2234,7 +2234,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to list leases under. Example: \&quot;aws/creds/deploy\&quot;</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2247,7 +2247,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="format">Format to export metrics into. Currently accepts only \&quot;prometheus\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2259,7 +2259,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="logFormat">Output format of logs. Supported values are \&quot;standard\&quot; and \&quot;json\&quot;. The default is \&quot;standard\&quot;. (optional, default to &quot;standard&quot;)</param>
         /// <param name="logLevel">Log level to view system logs at. Currently supported values are \&quot;trace\&quot;, \&quot;debug\&quot;, \&quot;info\&quot;, \&quot;warn\&quot;, \&quot;error\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2272,7 +2272,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysMountsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2283,7 +2283,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2295,7 +2295,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2307,7 +2307,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPluginsCatalogAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2318,7 +2318,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2330,7 +2330,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2343,7 +2343,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2356,7 +2356,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2368,7 +2368,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2380,7 +2380,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2392,7 +2392,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2404,7 +2404,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2416,7 +2416,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2428,7 +2428,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2440,7 +2440,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns an HTML page listing the available  profiles. This should be mainly accessed via browsers or applications that can  render pages.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2451,7 +2451,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns a sampling of all past memory allocations.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofAllocsAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2462,7 +2462,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces that led to blocking on synchronization primitives
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofBlockAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2473,7 +2473,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns the running program&#39;s command line, with arguments separated by NUL bytes.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofCmdlineAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2484,7 +2484,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces of all current goroutines.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofGoroutineAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2495,7 +2495,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns a sampling of memory allocations of live object.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofHeapAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2506,7 +2506,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces of holders of contended mutexes
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofMutexAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2517,7 +2517,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns a pprof-formatted cpu profile payload. Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofProfileAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2528,7 +2528,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns the program counters listed in the request.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofSymbolAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2539,7 +2539,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns stack traces that led to the creation of new OS threads
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofThreadcreateAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2550,7 +2550,7 @@ namespace Vault.Api
         /// <remarks>
         /// Returns  the execution trace in binary form. Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysPprofTraceAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2561,7 +2561,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysQuotasConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2572,7 +2572,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2584,7 +2584,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2596,7 +2596,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2608,7 +2608,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2621,7 +2621,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysRekeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2632,7 +2632,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysRekeyInitAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2643,7 +2643,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysRekeyRecoveryKeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2654,7 +2654,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysRekeyVerifyAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2665,7 +2665,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="migrationId">The ID of the migration operation</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2677,7 +2677,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysReplicationStatusAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2688,7 +2688,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysRotateConfigAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2699,7 +2699,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysSealStatusAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2710,7 +2710,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2722,7 +2722,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> GetSysWrappingLookupAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -2733,7 +2733,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2746,7 +2746,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2759,7 +2759,7 @@ namespace Vault.Api
         /// <remarks>
         /// After enabling, the auth method can be accessed and configured via the auth path specified as part of the URL. This auth path will be nested under the auth prefix.  For example, enable the \&quot;foo\&quot; auth method will make it accessible at /auth/foo.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="systemAuthRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2772,7 +2772,7 @@ namespace Vault.Api
         /// <remarks>
         /// This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <param name="systemAuthTuneRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2785,7 +2785,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2797,7 +2797,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2809,7 +2809,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesSelfRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2821,7 +2821,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="systemConfigAuditingRequestHeadersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2834,7 +2834,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemConfigCorsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2846,7 +2846,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="subsystem"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2858,7 +2858,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="systemConfigUiHeadersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2871,7 +2871,7 @@ namespace Vault.Api
         /// <remarks>
         /// Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2883,7 +2883,7 @@ namespace Vault.Api
         /// <remarks>
         /// Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootAttemptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2895,7 +2895,7 @@ namespace Vault.Api
         /// <remarks>
         /// If the threshold number of unseal key shares is reached, Vault will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootUpdateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2907,7 +2907,7 @@ namespace Vault.Api
         /// <remarks>
         /// The Vault must not have been previously initialized. The recovery options, as well as the stored shares option, are only available when using Vault HSM.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInitRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2919,7 +2919,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInternalCountersConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2931,7 +2931,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2943,7 +2943,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRenewRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2955,7 +2955,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRenewLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -2968,7 +2968,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2980,7 +2980,7 @@ namespace Vault.Api
         /// <remarks>
         /// Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -2992,7 +2992,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemLeasesRevokePrefixRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3005,7 +3005,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRevokeLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3018,7 +3018,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostSysLeasesTidyAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3029,7 +3029,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemMfaValidateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3041,7 +3041,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3054,7 +3054,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsTuneRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3067,7 +3067,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3080,7 +3080,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
@@ -3094,7 +3094,7 @@ namespace Vault.Api
         /// <remarks>
         /// Either the plugin name (&#x60;plugin&#x60;) or the desired plugin backend mounts (&#x60;mounts&#x60;) must be provided, but not both. In the case that the plugin name is provided, all mounted paths that use that plugin backend will be reloaded.  If (&#x60;scope&#x60;) is provided and is (&#x60;global&#x60;), the plugin(s) are reloaded globally.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemPluginsReloadBackendRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3106,7 +3106,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPoliciesAclRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3119,7 +3119,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="systemPoliciesPasswordRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3132,7 +3132,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPolicyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3145,7 +3145,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemQuotasConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3157,7 +3157,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="systemQuotasRateLimitRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3170,7 +3170,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3182,7 +3182,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3195,7 +3195,7 @@ namespace Vault.Api
         /// <remarks>
         /// Only a single rekey attempt can take place at a time, and changing the parameters of a rekey requires canceling and starting a new rekey, which will also provide a new nonce.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyInitRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3207,7 +3207,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyUpdateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3219,7 +3219,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3231,7 +3231,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRemountRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3243,7 +3243,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRenewRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3255,7 +3255,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRenewLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3268,7 +3268,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3280,7 +3280,7 @@ namespace Vault.Api
         /// <remarks>
         /// Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3292,7 +3292,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemRevokePrefixRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3305,7 +3305,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRevokeLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3318,7 +3318,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostSysRotateAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3329,7 +3329,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRotateConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3341,7 +3341,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostSysSealAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3352,7 +3352,7 @@ namespace Vault.Api
         /// <remarks>
         /// This endpoint forces the node to give up active status. If the node does not have active status, this endpoint does nothing. Note that the node will sleep for ten seconds before attempting to grab the active lock again, but if no standby nodes grab the active lock in the interim, the same node may become the active node again.
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostSysStepDownAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3363,7 +3363,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3375,7 +3375,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3388,7 +3388,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3400,7 +3400,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3413,7 +3413,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
@@ -3427,7 +3427,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -3440,7 +3440,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemUnsealRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3452,7 +3452,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3464,7 +3464,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingRewrapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3476,7 +3476,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingUnwrapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3488,7 +3488,7 @@ namespace Vault.Api
         /// <remarks>
         /// 
         /// </remarks>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         Task<ApiResponse<Object>> PostSysWrappingWrapAsync(CancellationToken cancellationToken = default(CancellationToken));
@@ -3517,7 +3517,7 @@ namespace Vault.Api
             this.Configuration = apiClient.Configuration;
             this.Client = apiClient;
             this.AsynchronousClient = apiClient;
-            this.ExceptionFactory = Vault.Client.Configuration.DefaultExceptionFactory;
+            this.ExceptionFactory = Configuration.DefaultExceptionFactory;
         }
 
         /// <summary>
@@ -3565,14 +3565,14 @@ namespace Vault.Api
         /// <summary>
         /// Disable the audit device at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysAuditPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuditPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuditPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3607,7 +3607,7 @@ namespace Vault.Api
         /// <summary>
         /// Disable the audit device at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3615,7 +3615,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuditPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuditPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3651,14 +3651,14 @@ namespace Vault.Api
         /// <summary>
         /// Disable the auth method at the given auth path 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysAuthPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuthPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuthPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3693,7 +3693,7 @@ namespace Vault.Api
         /// <summary>
         /// Disable the auth method at the given auth path 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3701,7 +3701,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuthPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysAuthPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3737,14 +3737,14 @@ namespace Vault.Api
         /// <summary>
         /// Disable auditing of the given request header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysConfigAuditingRequestHeadersHeader(string header)
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigAuditingRequestHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigAuditingRequestHeadersHeader");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3779,7 +3779,7 @@ namespace Vault.Api
         /// <summary>
         /// Disable auditing of the given request header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3787,7 +3787,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigAuditingRequestHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigAuditingRequestHeadersHeader");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3823,7 +3823,7 @@ namespace Vault.Api
         /// <summary>
         /// Remove any CORS settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysConfigCors()
         {
@@ -3859,7 +3859,7 @@ namespace Vault.Api
         /// <summary>
         /// Remove any CORS settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysConfigCorsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -3897,14 +3897,14 @@ namespace Vault.Api
         /// <summary>
         /// Remove a UI header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysConfigUiHeadersHeader(string header)
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigUiHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigUiHeadersHeader");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -3939,7 +3939,7 @@ namespace Vault.Api
         /// <summary>
         /// Remove a UI header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -3947,7 +3947,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigUiHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->DeleteSysConfigUiHeadersHeader");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -3983,7 +3983,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancels any in-progress root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysGenerateRoot()
         {
@@ -4019,7 +4019,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancels any in-progress root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysGenerateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -4057,7 +4057,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancels any in-progress root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysGenerateRootAttempt()
         {
@@ -4093,7 +4093,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancels any in-progress root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysGenerateRootAttemptAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -4131,14 +4131,14 @@ namespace Vault.Api
         /// <summary>
         /// Disable the mount point specified at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysMountsPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysMountsPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4173,7 +4173,7 @@ namespace Vault.Api
         /// <summary>
         /// Disable the mount point specified at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4181,7 +4181,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysMountsPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4217,14 +4217,14 @@ namespace Vault.Api
         /// <summary>
         /// Remove the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysPluginsCatalogName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4259,7 +4259,7 @@ namespace Vault.Api
         /// <summary>
         /// Remove the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4267,7 +4267,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4303,7 +4303,7 @@ namespace Vault.Api
         /// <summary>
         /// Remove the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -4311,11 +4311,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->DeleteSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->DeleteSysPluginsCatalogTypeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4351,7 +4351,7 @@ namespace Vault.Api
         /// <summary>
         /// Remove the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -4360,11 +4360,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPluginsCatalogTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->DeleteSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->DeleteSysPluginsCatalogTypeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4401,14 +4401,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete the ACL policy with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysPoliciesAclName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesAclName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesAclName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4443,7 +4443,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete the ACL policy with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4451,7 +4451,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesAclName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesAclName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4487,14 +4487,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete a password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysPoliciesPasswordName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesPasswordName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesPasswordName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4529,7 +4529,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete a password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4537,7 +4537,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesPasswordName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPoliciesPasswordName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4573,14 +4573,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete the policy with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysPolicyName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPolicyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPolicyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4615,7 +4615,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete the policy with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4623,7 +4623,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPolicyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysPolicyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4659,14 +4659,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysQuotasRateLimitName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysQuotasRateLimitName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysQuotasRateLimitName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4701,7 +4701,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4709,7 +4709,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->DeleteSysQuotasRateLimitName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->DeleteSysQuotasRateLimitName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4745,7 +4745,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete the key with given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysRaw()
         {
@@ -4781,7 +4781,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete the key with given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysRawAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -4819,14 +4819,14 @@ namespace Vault.Api
         /// <summary>
         /// Delete the key with given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysRawPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysRawPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysRawPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -4861,7 +4861,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete the key with given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -4869,7 +4869,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->DeleteSysRawPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->DeleteSysRawPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -4905,7 +4905,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete the backup copy of PGP-encrypted unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysRekeyBackup()
         {
@@ -4941,7 +4941,7 @@ namespace Vault.Api
         /// <summary>
         /// Delete the backup copy of PGP-encrypted unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysRekeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -4979,7 +4979,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancels any in-progress rekey. This clears the rekey settings as well as any progress made. This must be called to change the parameters of the rekey. Note: verification is still a part of a rekey. If rekeying is canceled during the verification flow, the current unseal keys remain valid.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysRekeyInit()
         {
@@ -5015,7 +5015,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancels any in-progress rekey. This clears the rekey settings as well as any progress made. This must be called to change the parameters of the rekey. Note: verification is still a part of a rekey. If rekeying is canceled during the verification flow, the current unseal keys remain valid.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysRekeyInitAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5053,7 +5053,7 @@ namespace Vault.Api
         /// <summary>
         /// Allows fetching or deleting the backup of the rotated unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysRekeyRecoveryKeyBackup()
         {
@@ -5089,7 +5089,7 @@ namespace Vault.Api
         /// <summary>
         /// Allows fetching or deleting the backup of the rotated unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysRekeyRecoveryKeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5127,7 +5127,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancel any in-progress rekey verification operation. This clears any progress made and resets the nonce. Unlike a &#x60;DELETE&#x60; against &#x60;sys/rekey/init&#x60;, this only resets the current verification operation, not the entire rekey atttempt.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> DeleteSysRekeyVerify()
         {
@@ -5163,7 +5163,7 @@ namespace Vault.Api
         /// <summary>
         /// Cancel any in-progress rekey verification operation. This clears any progress made and resets the nonce. Unlike a &#x60;DELETE&#x60; against &#x60;sys/rekey/init&#x60;, this only resets the current verification operation, not the entire rekey atttempt.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> DeleteSysRekeyVerifyAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5201,7 +5201,7 @@ namespace Vault.Api
         /// <summary>
         /// List the enabled audit devices. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysAudit()
         {
@@ -5237,7 +5237,7 @@ namespace Vault.Api
         /// <summary>
         /// List the enabled audit devices. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysAuditAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5275,7 +5275,7 @@ namespace Vault.Api
         /// <summary>
         /// List the currently enabled credential backends. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysAuth()
         {
@@ -5311,7 +5311,7 @@ namespace Vault.Api
         /// <summary>
         /// List the currently enabled credential backends. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysAuthAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5349,14 +5349,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration of the auth engine at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysAuthPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5391,7 +5391,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration of the auth engine at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5399,7 +5399,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5435,14 +5435,14 @@ namespace Vault.Api
         /// <summary>
         /// Reads the given auth path&#39;s configuration. This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysAuthPathTune(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPathTune");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5477,7 +5477,7 @@ namespace Vault.Api
         /// <summary>
         /// Reads the given auth path&#39;s configuration. This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5485,7 +5485,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysAuthPathTune");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5521,7 +5521,7 @@ namespace Vault.Api
         /// <summary>
         /// List the request headers that are configured to be audited. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysConfigAuditingRequestHeaders()
         {
@@ -5557,7 +5557,7 @@ namespace Vault.Api
         /// <summary>
         /// List the request headers that are configured to be audited. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysConfigAuditingRequestHeadersAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5595,14 +5595,14 @@ namespace Vault.Api
         /// <summary>
         /// List the information for the given request header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysConfigAuditingRequestHeadersHeader(string header)
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigAuditingRequestHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigAuditingRequestHeadersHeader");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5637,7 +5637,7 @@ namespace Vault.Api
         /// <summary>
         /// List the information for the given request header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5645,7 +5645,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigAuditingRequestHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigAuditingRequestHeadersHeader");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5681,7 +5681,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the current CORS settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysConfigCors()
         {
@@ -5717,7 +5717,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the current CORS settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysConfigCorsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5755,7 +5755,7 @@ namespace Vault.Api
         /// <summary>
         /// Return a sanitized version of the Vault server configuration. The sanitized output strips configuration values in the storage, HA storage, and seals stanzas, which may contain sensitive values such as API tokens. It also removes any token or secret fields in other stanzas, such as the circonus_api_token from telemetry.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysConfigStateSanitized()
         {
@@ -5791,7 +5791,7 @@ namespace Vault.Api
         /// <summary>
         /// Return a sanitized version of the Vault server configuration. The sanitized output strips configuration values in the storage, HA storage, and seals stanzas, which may contain sensitive values such as API tokens. It also removes any token or secret fields in other stanzas, such as the circonus_api_token from telemetry.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysConfigStateSanitizedAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -5829,14 +5829,14 @@ namespace Vault.Api
         /// <summary>
         /// Return a list of configured UI headers. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysConfigUiHeaders(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysConfigUiHeaders");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysConfigUiHeaders");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5871,7 +5871,7 @@ namespace Vault.Api
         /// <summary>
         /// Return a list of configured UI headers. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5879,7 +5879,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysConfigUiHeaders");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysConfigUiHeaders");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -5915,14 +5915,14 @@ namespace Vault.Api
         /// <summary>
         /// Return the given UI header&#39;s configuration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysConfigUiHeadersHeader(string header)
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigUiHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigUiHeadersHeader");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -5957,7 +5957,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the given UI header&#39;s configuration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -5965,7 +5965,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigUiHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->GetSysConfigUiHeadersHeader");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -6001,7 +6001,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration and progress of the current root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysGenerateRoot()
         {
@@ -6037,7 +6037,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration and progress of the current root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysGenerateRootAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6075,7 +6075,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration and progress of the current root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysGenerateRootAttempt()
         {
@@ -6111,7 +6111,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration and progress of the current root generation attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysGenerateRootAttemptAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6149,7 +6149,7 @@ namespace Vault.Api
         /// <summary>
         /// Check the HA status of a Vault cluster 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysHaStatus()
         {
@@ -6185,7 +6185,7 @@ namespace Vault.Api
         /// <summary>
         /// Check the HA status of a Vault cluster 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysHaStatusAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6223,7 +6223,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the health status of Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysHealth()
         {
@@ -6259,7 +6259,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the health status of Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysHealthAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6297,7 +6297,7 @@ namespace Vault.Api
         /// <summary>
         /// Information about the host instance that this Vault server is running on. Information about the host instance that this Vault server is running on.   The information that gets collected includes host hardware information, and CPU,   disk, and memory utilization
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysHostInfo()
         {
@@ -6333,7 +6333,7 @@ namespace Vault.Api
         /// <summary>
         /// Information about the host instance that this Vault server is running on. Information about the host instance that this Vault server is running on.   The information that gets collected includes host hardware information, and CPU,   disk, and memory utilization
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysHostInfoAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6371,7 +6371,7 @@ namespace Vault.Api
         /// <summary>
         /// reports in-flight requests This path responds to the following HTTP methods.   GET /    Returns a map of in-flight requests.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInFlightReq()
         {
@@ -6407,7 +6407,7 @@ namespace Vault.Api
         /// <summary>
         /// reports in-flight requests This path responds to the following HTTP methods.   GET /    Returns a map of in-flight requests.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInFlightReqAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6445,7 +6445,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the initialization status of Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInit()
         {
@@ -6481,7 +6481,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the initialization status of Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInitAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6519,7 +6519,7 @@ namespace Vault.Api
         /// <summary>
         /// Report the client count metrics, for this namespace and all child namespaces. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalCountersActivity()
         {
@@ -6555,7 +6555,7 @@ namespace Vault.Api
         /// <summary>
         /// Report the client count metrics, for this namespace and all child namespaces. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalCountersActivityAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6593,7 +6593,7 @@ namespace Vault.Api
         /// <summary>
         /// Report the client count metrics, for this namespace and all child namespaces. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalCountersActivityExport()
         {
@@ -6629,7 +6629,7 @@ namespace Vault.Api
         /// <summary>
         /// Report the client count metrics, for this namespace and all child namespaces. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalCountersActivityExportAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6667,7 +6667,7 @@ namespace Vault.Api
         /// <summary>
         /// Report the number of clients for this month, for this namespace and all child namespaces. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalCountersActivityMonthly()
         {
@@ -6703,7 +6703,7 @@ namespace Vault.Api
         /// <summary>
         /// Report the number of clients for this month, for this namespace and all child namespaces. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalCountersActivityMonthlyAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6741,7 +6741,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the client count tracking configuration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalCountersConfig()
         {
@@ -6777,7 +6777,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the client count tracking configuration. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalCountersConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6815,7 +6815,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalCountersEntities()
         {
@@ -6851,7 +6851,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalCountersEntitiesAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6889,7 +6889,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalCountersRequests()
         {
@@ -6925,7 +6925,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalCountersRequestsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -6963,7 +6963,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalCountersTokens()
         {
@@ -6999,7 +6999,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalCountersTokensAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7037,7 +7037,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an OpenAPI 3 document of all mounted paths. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalSpecsOpenapi()
         {
@@ -7073,7 +7073,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate an OpenAPI 3 document of all mounted paths. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalSpecsOpenapiAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7111,7 +7111,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists enabled feature flags. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalUiFeatureFlags()
         {
@@ -7147,7 +7147,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists enabled feature flags. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalUiFeatureFlagsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7185,7 +7185,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all enabled and visible auth and secrets mounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalUiMounts()
         {
@@ -7221,7 +7221,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all enabled and visible auth and secrets mounts. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalUiMountsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7259,14 +7259,14 @@ namespace Vault.Api
         /// <summary>
         /// Return information about the given mount. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path of the mount.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalUiMountsPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysInternalUiMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysInternalUiMountsPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7301,7 +7301,7 @@ namespace Vault.Api
         /// <summary>
         /// Return information about the given mount. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path of the mount.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7309,7 +7309,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysInternalUiMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysInternalUiMountsPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7345,7 +7345,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalUiNamespaces()
         {
@@ -7381,7 +7381,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalUiNamespacesAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7419,7 +7419,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysInternalUiResultantAcl()
         {
@@ -7455,7 +7455,7 @@ namespace Vault.Api
         /// <summary>
         /// Backwards compatibility is not guaranteed for this API 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysInternalUiResultantAclAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7493,7 +7493,7 @@ namespace Vault.Api
         /// <summary>
         /// Provides information about the backend encryption key. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysKeyStatus()
         {
@@ -7529,7 +7529,7 @@ namespace Vault.Api
         /// <summary>
         /// Provides information about the backend encryption key. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysKeyStatusAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7567,7 +7567,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the high availability status and current leader instance of Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysLeader()
         {
@@ -7603,7 +7603,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the high availability status and current leader instance of Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysLeaderAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7641,7 +7641,7 @@ namespace Vault.Api
         /// <summary>
         /// List leases associated with this Vault cluster 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysLeases()
         {
@@ -7677,7 +7677,7 @@ namespace Vault.Api
         /// <summary>
         /// List leases associated with this Vault cluster 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysLeasesAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7715,7 +7715,7 @@ namespace Vault.Api
         /// <summary>
         /// Count of leases associated with this Vault cluster 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysLeasesCount()
         {
@@ -7751,7 +7751,7 @@ namespace Vault.Api
         /// <summary>
         /// Count of leases associated with this Vault cluster 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysLeasesCountAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -7789,14 +7789,14 @@ namespace Vault.Api
         /// <summary>
         /// Returns a list of lease ids. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysLeasesLookup(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookup");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookup");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7831,7 +7831,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a list of lease ids. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -7839,7 +7839,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookup");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookup");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7875,7 +7875,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a list of lease ids. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to list leases under. Example: \&quot;aws/creds/deploy\&quot;</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -7883,11 +7883,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->GetSysLeasesLookupPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->GetSysLeasesLookupPrefix");
 
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookupPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookupPrefix");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -7923,7 +7923,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a list of lease ids. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to list leases under. Example: \&quot;aws/creds/deploy\&quot;</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -7932,11 +7932,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->GetSysLeasesLookupPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->GetSysLeasesLookupPrefix");
 
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookupPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysLeasesLookupPrefix");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -7973,7 +7973,7 @@ namespace Vault.Api
         /// <summary>
         /// Export the metrics aggregated for telemetry purpose. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="format">Format to export metrics into. Currently accepts only \&quot;prometheus\&quot;. (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysMetrics(string format = default(string))
@@ -8014,7 +8014,7 @@ namespace Vault.Api
         /// <summary>
         /// Export the metrics aggregated for telemetry purpose. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="format">Format to export metrics into. Currently accepts only \&quot;prometheus\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8057,7 +8057,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="logFormat">Output format of logs. Supported values are \&quot;standard\&quot; and \&quot;json\&quot;. The default is \&quot;standard\&quot;. (optional, default to &quot;standard&quot;)</param>
         /// <param name="logLevel">Log level to view system logs at. Currently supported values are \&quot;trace\&quot;, \&quot;debug\&quot;, \&quot;info\&quot;, \&quot;warn\&quot;, \&quot;error\&quot;. (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -8103,7 +8103,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="logFormat">Output format of logs. Supported values are \&quot;standard\&quot; and \&quot;json\&quot;. The default is \&quot;standard\&quot;. (optional, default to &quot;standard&quot;)</param>
         /// <param name="logLevel">Log level to view system logs at. Currently supported values are \&quot;trace\&quot;, \&quot;debug\&quot;, \&quot;info\&quot;, \&quot;warn\&quot;, \&quot;error\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -8151,7 +8151,7 @@ namespace Vault.Api
         /// <summary>
         /// List the currently mounted backends. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysMounts()
         {
@@ -8187,7 +8187,7 @@ namespace Vault.Api
         /// <summary>
         /// List the currently mounted backends. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysMountsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8225,14 +8225,14 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration of the secret engine at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysMountsPath(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8267,7 +8267,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration of the secret engine at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8275,7 +8275,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8311,14 +8311,14 @@ namespace Vault.Api
         /// <summary>
         /// Tune backend configuration parameters for this mount. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysMountsPathTune(string path)
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPathTune");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8353,7 +8353,7 @@ namespace Vault.Api
         /// <summary>
         /// Tune backend configuration parameters for this mount. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8361,7 +8361,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysMountsPathTune");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8397,7 +8397,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the plugins known to Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPluginsCatalog()
         {
@@ -8433,7 +8433,7 @@ namespace Vault.Api
         /// <summary>
         /// Lists all the plugins known to Vault 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPluginsCatalogAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -8471,14 +8471,14 @@ namespace Vault.Api
         /// <summary>
         /// Return the configuration data for the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPluginsCatalogName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8513,7 +8513,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the configuration data for the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8521,7 +8521,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8557,7 +8557,7 @@ namespace Vault.Api
         /// <summary>
         /// List the plugins in the catalog. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -8565,11 +8565,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogType");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogType");
 
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysPluginsCatalogType");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysPluginsCatalogType");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8605,7 +8605,7 @@ namespace Vault.Api
         /// <summary>
         /// List the plugins in the catalog. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -8614,11 +8614,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogType");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogType");
 
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysPluginsCatalogType");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysPluginsCatalogType");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8655,7 +8655,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the configuration data for the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -8663,11 +8663,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogTypeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8703,7 +8703,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the configuration data for the plugin with the given name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -8712,11 +8712,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPluginsCatalogTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->GetSysPluginsCatalogTypeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8753,14 +8753,14 @@ namespace Vault.Api
         /// <summary>
         /// List the configured access control policies. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPoliciesAcl(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesAcl");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesAcl");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8795,7 +8795,7 @@ namespace Vault.Api
         /// <summary>
         /// List the configured access control policies. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8803,7 +8803,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesAcl");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesAcl");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8839,14 +8839,14 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve information about the named ACL policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPoliciesAclName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesAclName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesAclName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8881,7 +8881,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve information about the named ACL policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8889,7 +8889,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesAclName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesAclName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -8925,14 +8925,14 @@ namespace Vault.Api
         /// <summary>
         /// List the existing password policies. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPoliciesPassword(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesPassword");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesPassword");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -8967,7 +8967,7 @@ namespace Vault.Api
         /// <summary>
         /// List the existing password policies. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -8975,7 +8975,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesPassword");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysPoliciesPassword");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9011,14 +9011,14 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve an existing password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPoliciesPasswordName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9053,7 +9053,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve an existing password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9061,7 +9061,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9097,14 +9097,14 @@ namespace Vault.Api
         /// <summary>
         /// Generate a password from an existing password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPoliciesPasswordNameGenerate(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordNameGenerate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordNameGenerate");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9139,7 +9139,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a password from an existing password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9147,7 +9147,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordNameGenerate");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPoliciesPasswordNameGenerate");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9183,7 +9183,7 @@ namespace Vault.Api
         /// <summary>
         /// List the configured access control policies. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPolicy(string list = default(string))
@@ -9224,7 +9224,7 @@ namespace Vault.Api
         /// <summary>
         /// List the configured access control policies. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9267,14 +9267,14 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the policy body for the named policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPolicyName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPolicyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPolicyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -9309,7 +9309,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve the policy body for the named policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -9317,7 +9317,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysPolicyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysPolicyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -9353,7 +9353,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns an HTML page listing the available profiles. Returns an HTML page listing the available  profiles. This should be mainly accessed via browsers or applications that can  render pages.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprof()
         {
@@ -9389,7 +9389,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns an HTML page listing the available profiles. Returns an HTML page listing the available  profiles. This should be mainly accessed via browsers or applications that can  render pages.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9427,7 +9427,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a sampling of all past memory allocations. Returns a sampling of all past memory allocations.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofAllocs()
         {
@@ -9463,7 +9463,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a sampling of all past memory allocations. Returns a sampling of all past memory allocations.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofAllocsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9501,7 +9501,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces that led to blocking on synchronization primitives Returns stack traces that led to blocking on synchronization primitives
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofBlock()
         {
@@ -9537,7 +9537,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces that led to blocking on synchronization primitives Returns stack traces that led to blocking on synchronization primitives
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofBlockAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9575,7 +9575,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the running program&#39;s command line. Returns the running program&#39;s command line, with arguments separated by NUL bytes.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofCmdline()
         {
@@ -9611,7 +9611,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the running program&#39;s command line. Returns the running program&#39;s command line, with arguments separated by NUL bytes.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofCmdlineAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9649,7 +9649,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces of all current goroutines. Returns stack traces of all current goroutines.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofGoroutine()
         {
@@ -9685,7 +9685,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces of all current goroutines. Returns stack traces of all current goroutines.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofGoroutineAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9723,7 +9723,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a sampling of memory allocations of live object. Returns a sampling of memory allocations of live object.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofHeap()
         {
@@ -9759,7 +9759,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a sampling of memory allocations of live object. Returns a sampling of memory allocations of live object.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofHeapAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9797,7 +9797,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces of holders of contended mutexes Returns stack traces of holders of contended mutexes
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofMutex()
         {
@@ -9833,7 +9833,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces of holders of contended mutexes Returns stack traces of holders of contended mutexes
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofMutexAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9871,7 +9871,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a pprof-formatted cpu profile payload. Returns a pprof-formatted cpu profile payload. Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofProfile()
         {
@@ -9907,7 +9907,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns a pprof-formatted cpu profile payload. Returns a pprof-formatted cpu profile payload. Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofProfileAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -9945,7 +9945,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the program counters listed in the request. Returns the program counters listed in the request.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofSymbol()
         {
@@ -9981,7 +9981,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the program counters listed in the request. Returns the program counters listed in the request.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofSymbolAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10019,7 +10019,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces that led to the creation of new OS threads Returns stack traces that led to the creation of new OS threads
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofThreadcreate()
         {
@@ -10055,7 +10055,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns stack traces that led to the creation of new OS threads Returns stack traces that led to the creation of new OS threads
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofThreadcreateAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10093,7 +10093,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the execution trace in binary form. Returns  the execution trace in binary form. Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysPprofTrace()
         {
@@ -10129,7 +10129,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns the execution trace in binary form. Returns  the execution trace in binary form. Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysPprofTraceAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10167,7 +10167,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysQuotasConfig()
         {
@@ -10203,7 +10203,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysQuotasConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10241,14 +10241,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysQuotasRateLimit(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysQuotasRateLimit");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysQuotasRateLimit");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10283,7 +10283,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10291,7 +10291,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysQuotasRateLimit");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysQuotasRateLimit");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10327,14 +10327,14 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysQuotasRateLimitName(string name)
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysQuotasRateLimitName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysQuotasRateLimitName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10369,7 +10369,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10377,7 +10377,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->GetSysQuotasRateLimitName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->GetSysQuotasRateLimitName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10413,7 +10413,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysRaw(string list = default(string))
@@ -10454,7 +10454,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10497,7 +10497,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -10505,7 +10505,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysRawPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysRawPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10544,7 +10544,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="list">Return a list if &#x60;true&#x60; (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -10553,7 +10553,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->GetSysRawPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->GetSysRawPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10593,7 +10593,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the backup copy of PGP-encrypted unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysRekeyBackup()
         {
@@ -10629,7 +10629,7 @@ namespace Vault.Api
         /// <summary>
         /// Return the backup copy of PGP-encrypted unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysRekeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10667,7 +10667,7 @@ namespace Vault.Api
         /// <summary>
         /// Reads the configuration and progress of the current rekey attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysRekeyInit()
         {
@@ -10703,7 +10703,7 @@ namespace Vault.Api
         /// <summary>
         /// Reads the configuration and progress of the current rekey attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysRekeyInitAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10741,7 +10741,7 @@ namespace Vault.Api
         /// <summary>
         /// Allows fetching or deleting the backup of the rotated unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysRekeyRecoveryKeyBackup()
         {
@@ -10777,7 +10777,7 @@ namespace Vault.Api
         /// <summary>
         /// Allows fetching or deleting the backup of the rotated unseal keys. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysRekeyRecoveryKeyBackupAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10815,7 +10815,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration and progress of the current rekey verification attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysRekeyVerify()
         {
@@ -10851,7 +10851,7 @@ namespace Vault.Api
         /// <summary>
         /// Read the configuration and progress of the current rekey verification attempt. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysRekeyVerifyAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -10889,14 +10889,14 @@ namespace Vault.Api
         /// <summary>
         /// Check status of a mount migration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="migrationId">The ID of the migration operation</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysRemountStatusMigrationId(string migrationId)
         {
             // verify the required parameter 'migrationId' is set
             if (migrationId == null)
-                throw new ApiException(400, "Missing required parameter 'migrationId' when calling System->GetSysRemountStatusMigrationId");
+                throw new VaultApiException(400, "Missing required parameter 'migrationId' when calling System->GetSysRemountStatusMigrationId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -10931,7 +10931,7 @@ namespace Vault.Api
         /// <summary>
         /// Check status of a mount migration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="migrationId">The ID of the migration operation</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -10939,7 +10939,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'migrationId' is set
             if (migrationId == null)
-                throw new ApiException(400, "Missing required parameter 'migrationId' when calling System->GetSysRemountStatusMigrationId");
+                throw new VaultApiException(400, "Missing required parameter 'migrationId' when calling System->GetSysRemountStatusMigrationId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -10975,7 +10975,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysReplicationStatus()
         {
@@ -11011,7 +11011,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysReplicationStatusAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11049,7 +11049,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysRotateConfig()
         {
@@ -11085,7 +11085,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysRotateConfigAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11123,7 +11123,7 @@ namespace Vault.Api
         /// <summary>
         /// Check the seal status of a Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysSealStatus()
         {
@@ -11159,7 +11159,7 @@ namespace Vault.Api
         /// <summary>
         /// Check the seal status of a Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysSealStatusAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11197,14 +11197,14 @@ namespace Vault.Api
         /// <summary>
         /// Returns map of historical version change entries 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysVersionHistory(string list)
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysVersionHistory");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysVersionHistory");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11239,7 +11239,7 @@ namespace Vault.Api
         /// <summary>
         /// Returns map of historical version change entries 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="list">Must be set to &#x60;true&#x60;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11247,7 +11247,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'list' is set
             if (list == null)
-                throw new ApiException(400, "Missing required parameter 'list' when calling System->GetSysVersionHistory");
+                throw new VaultApiException(400, "Missing required parameter 'list' when calling System->GetSysVersionHistory");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11283,7 +11283,7 @@ namespace Vault.Api
         /// <summary>
         /// Look up wrapping properties for the requester&#39;s token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> GetSysWrappingLookup()
         {
@@ -11319,7 +11319,7 @@ namespace Vault.Api
         /// <summary>
         /// Look up wrapping properties for the requester&#39;s token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> GetSysWrappingLookupAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -11357,7 +11357,7 @@ namespace Vault.Api
         /// <summary>
         /// The hash of the given string via the given audit backend 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11365,7 +11365,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditHashPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditHashPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11402,7 +11402,7 @@ namespace Vault.Api
         /// <summary>
         /// The hash of the given string via the given audit backend 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11411,7 +11411,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditHashPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditHashPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11449,7 +11449,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable a new audit device at the supplied path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11457,7 +11457,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11494,7 +11494,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable a new audit device at the supplied path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The name of the backend. Cannot be delimited. Example: \&quot;mysql\&quot;</param>
         /// <param name="systemAuditRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11503,7 +11503,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuditPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11541,7 +11541,7 @@ namespace Vault.Api
         /// <summary>
         /// Enables a new auth method. After enabling, the auth method can be accessed and configured via the auth path specified as part of the URL. This auth path will be nested under the auth prefix.  For example, enable the \&quot;foo\&quot; auth method will make it accessible at /auth/foo.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="systemAuthRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11549,7 +11549,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11586,7 +11586,7 @@ namespace Vault.Api
         /// <summary>
         /// Enables a new auth method. After enabling, the auth method can be accessed and configured via the auth path specified as part of the URL. This auth path will be nested under the auth prefix.  For example, enable the \&quot;foo\&quot; auth method will make it accessible at /auth/foo.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Cannot be delimited. Example: \&quot;user\&quot;</param>
         /// <param name="systemAuthRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11595,7 +11595,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11633,7 +11633,7 @@ namespace Vault.Api
         /// <summary>
         /// Tune configuration parameters for a given auth path. This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <param name="systemAuthTuneRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11641,7 +11641,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPathTune");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -11678,7 +11678,7 @@ namespace Vault.Api
         /// <summary>
         /// Tune configuration parameters for a given auth path. This endpoint requires sudo capability on the final path, but the same functionality can be achieved without sudo via &#x60;sys/mounts/auth/[auth-path]/tune&#x60;.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">Tune the configuration parameters for an auth path.</param>
         /// <param name="systemAuthTuneRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -11687,7 +11687,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysAuthPathTune");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -11725,7 +11725,7 @@ namespace Vault.Api
         /// <summary>
         /// Fetches the capabilities of the given token on the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysCapabilities(SystemCapabilitiesRequest systemCapabilitiesRequest = default(SystemCapabilitiesRequest))
@@ -11764,7 +11764,7 @@ namespace Vault.Api
         /// <summary>
         /// Fetches the capabilities of the given token on the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11805,7 +11805,7 @@ namespace Vault.Api
         /// <summary>
         /// Fetches the capabilities of the token associated with the given token, on the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesAccessorRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysCapabilitiesAccessor(SystemCapabilitiesAccessorRequest systemCapabilitiesAccessorRequest = default(SystemCapabilitiesAccessorRequest))
@@ -11844,7 +11844,7 @@ namespace Vault.Api
         /// <summary>
         /// Fetches the capabilities of the token associated with the given token, on the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesAccessorRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11885,7 +11885,7 @@ namespace Vault.Api
         /// <summary>
         /// Fetches the capabilities of the given token on the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesSelfRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysCapabilitiesSelf(SystemCapabilitiesSelfRequest systemCapabilitiesSelfRequest = default(SystemCapabilitiesSelfRequest))
@@ -11924,7 +11924,7 @@ namespace Vault.Api
         /// <summary>
         /// Fetches the capabilities of the given token on the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemCapabilitiesSelfRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -11965,7 +11965,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable auditing of a header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="systemConfigAuditingRequestHeadersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -11973,7 +11973,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigAuditingRequestHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigAuditingRequestHeadersHeader");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12010,7 +12010,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable auditing of a header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header"></param>
         /// <param name="systemConfigAuditingRequestHeadersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -12019,7 +12019,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigAuditingRequestHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigAuditingRequestHeadersHeader");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12057,7 +12057,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the CORS settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemConfigCorsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysConfigCors(SystemConfigCorsRequest systemConfigCorsRequest = default(SystemConfigCorsRequest))
@@ -12096,7 +12096,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the CORS settings. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemConfigCorsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12137,14 +12137,14 @@ namespace Vault.Api
         /// <summary>
         /// Reload the given subsystem 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="subsystem"></param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysConfigReloadSubsystem(string subsystem)
         {
             // verify the required parameter 'subsystem' is set
             if (subsystem == null)
-                throw new ApiException(400, "Missing required parameter 'subsystem' when calling System->PostSysConfigReloadSubsystem");
+                throw new VaultApiException(400, "Missing required parameter 'subsystem' when calling System->PostSysConfigReloadSubsystem");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12179,7 +12179,7 @@ namespace Vault.Api
         /// <summary>
         /// Reload the given subsystem 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="subsystem"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12187,7 +12187,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'subsystem' is set
             if (subsystem == null)
-                throw new ApiException(400, "Missing required parameter 'subsystem' when calling System->PostSysConfigReloadSubsystem");
+                throw new VaultApiException(400, "Missing required parameter 'subsystem' when calling System->PostSysConfigReloadSubsystem");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12223,7 +12223,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the values to be returned for the UI header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="systemConfigUiHeadersRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -12231,7 +12231,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigUiHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigUiHeadersHeader");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12268,7 +12268,7 @@ namespace Vault.Api
         /// <summary>
         /// Configure the values to be returned for the UI header. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="header">The name of the header.</param>
         /// <param name="systemConfigUiHeadersRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -12277,7 +12277,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'header' is set
             if (header == null)
-                throw new ApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigUiHeadersHeader");
+                throw new VaultApiException(400, "Missing required parameter 'header' when calling System->PostSysConfigUiHeadersHeader");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12315,7 +12315,7 @@ namespace Vault.Api
         /// <summary>
         /// Initializes a new root generation attempt. Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysGenerateRoot(SystemGenerateRootRequest systemGenerateRootRequest = default(SystemGenerateRootRequest))
@@ -12354,7 +12354,7 @@ namespace Vault.Api
         /// <summary>
         /// Initializes a new root generation attempt. Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12395,7 +12395,7 @@ namespace Vault.Api
         /// <summary>
         /// Initializes a new root generation attempt. Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootAttemptRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysGenerateRootAttempt(SystemGenerateRootAttemptRequest systemGenerateRootAttemptRequest = default(SystemGenerateRootAttemptRequest))
@@ -12434,7 +12434,7 @@ namespace Vault.Api
         /// <summary>
         /// Initializes a new root generation attempt. Only a single root generation attempt can take place at a time. One (and only one) of otp or pgp_key are required.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootAttemptRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12475,7 +12475,7 @@ namespace Vault.Api
         /// <summary>
         /// Enter a single unseal key share to progress the root generation attempt. If the threshold number of unseal key shares is reached, Vault will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootUpdateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysGenerateRootUpdate(SystemGenerateRootUpdateRequest systemGenerateRootUpdateRequest = default(SystemGenerateRootUpdateRequest))
@@ -12514,7 +12514,7 @@ namespace Vault.Api
         /// <summary>
         /// Enter a single unseal key share to progress the root generation attempt. If the threshold number of unseal key shares is reached, Vault will complete the root generation and issue the new token. Otherwise, this API must be called multiple times until that threshold is met. The attempt nonce must be provided with each call.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemGenerateRootUpdateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12555,7 +12555,7 @@ namespace Vault.Api
         /// <summary>
         /// Initialize a new Vault. The Vault must not have been previously initialized. The recovery options, as well as the stored shares option, are only available when using Vault HSM.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInitRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysInit(SystemInitRequest systemInitRequest = default(SystemInitRequest))
@@ -12594,7 +12594,7 @@ namespace Vault.Api
         /// <summary>
         /// Initialize a new Vault. The Vault must not have been previously initialized. The recovery options, as well as the stored shares option, are only available when using Vault HSM.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInitRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12635,7 +12635,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable or disable collection of client count, set retention period, or set default reporting period. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInternalCountersConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysInternalCountersConfig(SystemInternalCountersConfigRequest systemInternalCountersConfigRequest = default(SystemInternalCountersConfigRequest))
@@ -12674,7 +12674,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable or disable collection of client count, set retention period, or set default reporting period. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemInternalCountersConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12715,7 +12715,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve lease metadata. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysLeasesLookup(SystemLeasesLookupRequest systemLeasesLookupRequest = default(SystemLeasesLookupRequest))
@@ -12754,7 +12754,7 @@ namespace Vault.Api
         /// <summary>
         /// Retrieve lease metadata. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12795,7 +12795,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRenewRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysLeasesRenew(SystemLeasesRenewRequest systemLeasesRenewRequest = default(SystemLeasesRenewRequest))
@@ -12834,7 +12834,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRenewRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -12875,7 +12875,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRenewLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -12883,7 +12883,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRenewUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRenewUrlLeaseId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -12920,7 +12920,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRenewLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -12929,7 +12929,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRenewUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRenewUrlLeaseId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -12967,7 +12967,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysLeasesRevoke(SystemLeasesRevokeRequest systemLeasesRevokeRequest = default(SystemLeasesRevokeRequest))
@@ -13006,7 +13006,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemLeasesRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13047,14 +13047,14 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets or tokens generated under a given prefix immediately Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysLeasesRevokeForcePrefix(string prefix)
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokeForcePrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokeForcePrefix");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13089,7 +13089,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets or tokens generated under a given prefix immediately Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13097,7 +13097,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokeForcePrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokeForcePrefix");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13133,7 +13133,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets (via a lease ID prefix) or tokens (via the tokens&#39; path property) generated under a given prefix immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemLeasesRevokePrefixRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -13141,7 +13141,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokePrefixPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokePrefixPrefix");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13178,7 +13178,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets (via a lease ID prefix) or tokens (via the tokens&#39; path property) generated under a given prefix immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemLeasesRevokePrefixRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -13187,7 +13187,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokePrefixPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysLeasesRevokePrefixPrefix");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13225,7 +13225,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRevokeLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -13233,7 +13233,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRevokeUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRevokeUrlLeaseId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13270,7 +13270,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemLeasesRevokeLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -13279,7 +13279,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRevokeUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysLeasesRevokeUrlLeaseId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13317,7 +13317,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint performs cleanup tasks that can be run if certain error conditions have occurred. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysLeasesTidy()
         {
@@ -13353,7 +13353,7 @@ namespace Vault.Api
         /// <summary>
         /// This endpoint performs cleanup tasks that can be run if certain error conditions have occurred. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostSysLeasesTidyAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -13391,7 +13391,7 @@ namespace Vault.Api
         /// <summary>
         /// Validates the login for the given MFA methods. Upon successful validation, it returns an auth response containing the client token 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemMfaValidateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysMfaValidate(SystemMfaValidateRequest systemMfaValidateRequest = default(SystemMfaValidateRequest))
@@ -13430,7 +13430,7 @@ namespace Vault.Api
         /// <summary>
         /// Validates the login for the given MFA methods. Upon successful validation, it returns an auth response containing the client token 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemMfaValidateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13471,7 +13471,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable a new secrets engine at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -13479,7 +13479,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13516,7 +13516,7 @@ namespace Vault.Api
         /// <summary>
         /// Enable a new secrets engine at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -13525,7 +13525,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13563,7 +13563,7 @@ namespace Vault.Api
         /// <summary>
         /// Tune backend configuration parameters for this mount. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsTuneRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -13571,7 +13571,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPathTune");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13608,7 +13608,7 @@ namespace Vault.Api
         /// <summary>
         /// Tune backend configuration parameters for this mount. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path">The path to mount to. Example: \&quot;aws/east\&quot;</param>
         /// <param name="systemMountsTuneRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -13617,7 +13617,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPathTune");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysMountsPathTune");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13655,7 +13655,7 @@ namespace Vault.Api
         /// <summary>
         /// Register a new plugin, or updates an existing one with the supplied name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -13663,7 +13663,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13700,7 +13700,7 @@ namespace Vault.Api
         /// <summary>
         /// Register a new plugin, or updates an existing one with the supplied name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -13709,7 +13709,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13747,7 +13747,7 @@ namespace Vault.Api
         /// <summary>
         /// Register a new plugin, or updates an existing one with the supplied name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
@@ -13756,11 +13756,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->PostSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->PostSysPluginsCatalogTypeName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13798,7 +13798,7 @@ namespace Vault.Api
         /// <summary>
         /// Register a new plugin, or updates an existing one with the supplied name. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the plugin</param>
         /// <param name="type">The type of the plugin, may be auth, secret, or database</param>
         /// <param name="systemPluginsCatalogRequest"> (optional)</param>
@@ -13808,11 +13808,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPluginsCatalogTypeName");
 
             // verify the required parameter 'type' is set
             if (type == null)
-                throw new ApiException(400, "Missing required parameter 'type' when calling System->PostSysPluginsCatalogTypeName");
+                throw new VaultApiException(400, "Missing required parameter 'type' when calling System->PostSysPluginsCatalogTypeName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -13851,7 +13851,7 @@ namespace Vault.Api
         /// <summary>
         /// Reload mounted plugin backends. Either the plugin name (&#x60;plugin&#x60;) or the desired plugin backend mounts (&#x60;mounts&#x60;) must be provided, but not both. In the case that the plugin name is provided, all mounted paths that use that plugin backend will be reloaded.  If (&#x60;scope&#x60;) is provided and is (&#x60;global&#x60;), the plugin(s) are reloaded globally.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemPluginsReloadBackendRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysPluginsReloadBackend(SystemPluginsReloadBackendRequest systemPluginsReloadBackendRequest = default(SystemPluginsReloadBackendRequest))
@@ -13890,7 +13890,7 @@ namespace Vault.Api
         /// <summary>
         /// Reload mounted plugin backends. Either the plugin name (&#x60;plugin&#x60;) or the desired plugin backend mounts (&#x60;mounts&#x60;) must be provided, but not both. In the case that the plugin name is provided, all mounted paths that use that plugin backend will be reloaded.  If (&#x60;scope&#x60;) is provided and is (&#x60;global&#x60;), the plugin(s) are reloaded globally.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemPluginsReloadBackendRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -13931,7 +13931,7 @@ namespace Vault.Api
         /// <summary>
         /// Add a new or update an existing ACL policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPoliciesAclRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -13939,7 +13939,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesAclName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesAclName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -13976,7 +13976,7 @@ namespace Vault.Api
         /// <summary>
         /// Add a new or update an existing ACL policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPoliciesAclRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -13985,7 +13985,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesAclName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesAclName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14023,7 +14023,7 @@ namespace Vault.Api
         /// <summary>
         /// Add a new or update an existing password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="systemPoliciesPasswordRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -14031,7 +14031,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesPasswordName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesPasswordName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14068,7 +14068,7 @@ namespace Vault.Api
         /// <summary>
         /// Add a new or update an existing password policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the password policy.</param>
         /// <param name="systemPoliciesPasswordRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -14077,7 +14077,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesPasswordName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPoliciesPasswordName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14115,7 +14115,7 @@ namespace Vault.Api
         /// <summary>
         /// Add a new or update an existing policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPolicyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -14123,7 +14123,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPolicyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPolicyName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14160,7 +14160,7 @@ namespace Vault.Api
         /// <summary>
         /// Add a new or update an existing policy. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">The name of the policy. Example: \&quot;ops\&quot;</param>
         /// <param name="systemPolicyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -14169,7 +14169,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysPolicyName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysPolicyName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14207,7 +14207,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemQuotasConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysQuotasConfig(SystemQuotasConfigRequest systemQuotasConfigRequest = default(SystemQuotasConfigRequest))
@@ -14246,7 +14246,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemQuotasConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14287,7 +14287,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="systemQuotasRateLimitRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -14295,7 +14295,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysQuotasRateLimitName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysQuotasRateLimitName");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14332,7 +14332,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="name">Name of the quota rule.</param>
         /// <param name="systemQuotasRateLimitRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -14341,7 +14341,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'name' is set
             if (name == null)
-                throw new ApiException(400, "Missing required parameter 'name' when calling System->PostSysQuotasRateLimitName");
+                throw new VaultApiException(400, "Missing required parameter 'name' when calling System->PostSysQuotasRateLimitName");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14379,7 +14379,7 @@ namespace Vault.Api
         /// <summary>
         /// Update the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRaw(SystemRawRequest systemRawRequest = default(SystemRawRequest))
@@ -14418,7 +14418,7 @@ namespace Vault.Api
         /// <summary>
         /// Update the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14459,7 +14459,7 @@ namespace Vault.Api
         /// <summary>
         /// Update the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -14467,7 +14467,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysRawPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysRawPath");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14504,7 +14504,7 @@ namespace Vault.Api
         /// <summary>
         /// Update the value of the key at the given path. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="path"></param>
         /// <param name="systemRawRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -14513,7 +14513,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'path' is set
             if (path == null)
-                throw new ApiException(400, "Missing required parameter 'path' when calling System->PostSysRawPath");
+                throw new VaultApiException(400, "Missing required parameter 'path' when calling System->PostSysRawPath");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -14551,7 +14551,7 @@ namespace Vault.Api
         /// <summary>
         /// Initializes a new rekey attempt. Only a single rekey attempt can take place at a time, and changing the parameters of a rekey requires canceling and starting a new rekey, which will also provide a new nonce.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyInitRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRekeyInit(SystemRekeyInitRequest systemRekeyInitRequest = default(SystemRekeyInitRequest))
@@ -14590,7 +14590,7 @@ namespace Vault.Api
         /// <summary>
         /// Initializes a new rekey attempt. Only a single rekey attempt can take place at a time, and changing the parameters of a rekey requires canceling and starting a new rekey, which will also provide a new nonce.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyInitRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14631,7 +14631,7 @@ namespace Vault.Api
         /// <summary>
         /// Enter a single unseal key share to progress the rekey of the Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyUpdateRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRekeyUpdate(SystemRekeyUpdateRequest systemRekeyUpdateRequest = default(SystemRekeyUpdateRequest))
@@ -14670,7 +14670,7 @@ namespace Vault.Api
         /// <summary>
         /// Enter a single unseal key share to progress the rekey of the Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyUpdateRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14711,7 +14711,7 @@ namespace Vault.Api
         /// <summary>
         /// Enter a single new key share to progress the rekey verification operation. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyVerifyRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRekeyVerify(SystemRekeyVerifyRequest systemRekeyVerifyRequest = default(SystemRekeyVerifyRequest))
@@ -14750,7 +14750,7 @@ namespace Vault.Api
         /// <summary>
         /// Enter a single new key share to progress the rekey verification operation. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRekeyVerifyRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14791,7 +14791,7 @@ namespace Vault.Api
         /// <summary>
         /// Initiate a mount migration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRemountRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRemount(SystemRemountRequest systemRemountRequest = default(SystemRemountRequest))
@@ -14830,7 +14830,7 @@ namespace Vault.Api
         /// <summary>
         /// Initiate a mount migration 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRemountRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14871,7 +14871,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRenewRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRenew(SystemRenewRequest systemRenewRequest = default(SystemRenewRequest))
@@ -14910,7 +14910,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRenewRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -14951,7 +14951,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRenewLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -14959,7 +14959,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRenewUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRenewUrlLeaseId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -14996,7 +14996,7 @@ namespace Vault.Api
         /// <summary>
         /// Renews a lease, requesting to extend the lease. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRenewLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -15005,7 +15005,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRenewUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRenewUrlLeaseId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15043,7 +15043,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRevokeRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRevoke(SystemRevokeRequest systemRevokeRequest = default(SystemRevokeRequest))
@@ -15082,7 +15082,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRevokeRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15123,14 +15123,14 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets or tokens generated under a given prefix immediately Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRevokeForcePrefix(string prefix)
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokeForcePrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokeForcePrefix");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15165,7 +15165,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets or tokens generated under a given prefix immediately Unlike &#x60;/sys/leases/revoke-prefix&#x60;, this path ignores backend errors encountered during revocation. This is potentially very dangerous and should only be used in specific emergency situations where errors in the backend or the connected backend service prevent normal revocation.  By ignoring these errors, Vault abdicates responsibility for ensuring that the issued credentials or secrets are properly revoked and/or cleaned up. Access to this endpoint should be tightly controlled.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15173,7 +15173,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokeForcePrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokeForcePrefix");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15209,7 +15209,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets (via a lease ID prefix) or tokens (via the tokens&#39; path property) generated under a given prefix immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemRevokePrefixRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -15217,7 +15217,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokePrefixPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokePrefixPrefix");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15254,7 +15254,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes all secrets (via a lease ID prefix) or tokens (via the tokens&#39; path property) generated under a given prefix immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="prefix">The path to revoke keys under. Example: \&quot;prod/aws/ops\&quot;</param>
         /// <param name="systemRevokePrefixRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -15263,7 +15263,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'prefix' is set
             if (prefix == null)
-                throw new ApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokePrefixPrefix");
+                throw new VaultApiException(400, "Missing required parameter 'prefix' when calling System->PostSysRevokePrefixPrefix");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15301,7 +15301,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRevokeLeaseRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -15309,7 +15309,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRevokeUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRevokeUrlLeaseId");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15346,7 +15346,7 @@ namespace Vault.Api
         /// <summary>
         /// Revokes a lease immediately. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlLeaseId">The lease identifier to renew. This is included with a lease.</param>
         /// <param name="systemRevokeLeaseRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -15355,7 +15355,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlLeaseId' is set
             if (urlLeaseId == null)
-                throw new ApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRevokeUrlLeaseId");
+                throw new VaultApiException(400, "Missing required parameter 'urlLeaseId' when calling System->PostSysRevokeUrlLeaseId");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15393,7 +15393,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotates the backend encryption key used to persist data. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRotate()
         {
@@ -15429,7 +15429,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotates the backend encryption key used to persist data. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostSysRotateAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15467,7 +15467,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRotateConfigRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysRotateConfig(SystemRotateConfigRequest systemRotateConfigRequest = default(SystemRotateConfigRequest))
@@ -15506,7 +15506,7 @@ namespace Vault.Api
         /// <summary>
         ///  
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemRotateConfigRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15547,7 +15547,7 @@ namespace Vault.Api
         /// <summary>
         /// Seal the Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysSeal()
         {
@@ -15583,7 +15583,7 @@ namespace Vault.Api
         /// <summary>
         /// Seal the Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostSysSealAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15621,7 +15621,7 @@ namespace Vault.Api
         /// <summary>
         /// Cause the node to give up active status. This endpoint forces the node to give up active status. If the node does not have active status, this endpoint does nothing. Note that the node will sleep for ten seconds before attempting to grab the active lock again, but if no standby nodes grab the active lock in the interim, the same node may become the active node again.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysStepDown()
         {
@@ -15657,7 +15657,7 @@ namespace Vault.Api
         /// <summary>
         /// Cause the node to give up active status. This endpoint forces the node to give up active status. If the node does not have active status, this endpoint does nothing. Note that the node will sleep for ten seconds before attempting to grab the active lock again, but if no standby nodes grab the active lock in the interim, the same node may become the active node again.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostSysStepDownAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -15695,7 +15695,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysToolsHash(SystemToolsHashRequest systemToolsHashRequest = default(SystemToolsHashRequest))
@@ -15734,7 +15734,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15775,7 +15775,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -15783,7 +15783,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling System->PostSysToolsHashUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling System->PostSysToolsHashUrlalgorithm");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15820,7 +15820,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate a hash sum for input data 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlalgorithm">Algorithm to use (POST URL parameter)</param>
         /// <param name="systemToolsHashRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -15829,7 +15829,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlalgorithm' is set
             if (urlalgorithm == null)
-                throw new ApiException(400, "Missing required parameter 'urlalgorithm' when calling System->PostSysToolsHashUrlalgorithm");
+                throw new VaultApiException(400, "Missing required parameter 'urlalgorithm' when calling System->PostSysToolsHashUrlalgorithm");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -15867,7 +15867,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysToolsRandom(SystemToolsRandomRequest systemToolsRandomRequest = default(SystemToolsRandomRequest))
@@ -15906,7 +15906,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -15947,7 +15947,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -15955,7 +15955,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSource");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSource");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -15992,7 +15992,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -16001,7 +16001,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSource");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSource");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16039,7 +16039,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
@@ -16048,11 +16048,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSourceUrlbytes");
 
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomSourceUrlbytes");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16090,7 +16090,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="source">Which system to source random data from, ether \&quot;platform\&quot;, \&quot;seal\&quot;, or \&quot;all\&quot;.</param>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
@@ -16100,11 +16100,11 @@ namespace Vault.Api
         {
             // verify the required parameter 'source' is set
             if (source == null)
-                throw new ApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'source' when calling System->PostSysToolsRandomSourceUrlbytes");
 
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomSourceUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomSourceUrlbytes");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16143,7 +16143,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
@@ -16151,7 +16151,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomUrlbytes");
 
             RequestOptions requestOptions = new RequestOptions();
 
@@ -16188,7 +16188,7 @@ namespace Vault.Api
         /// <summary>
         /// Generate random bytes 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="urlbytes">The number of bytes to generate (POST URL parameter)</param>
         /// <param name="systemToolsRandomRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -16197,7 +16197,7 @@ namespace Vault.Api
         {
             // verify the required parameter 'urlbytes' is set
             if (urlbytes == null)
-                throw new ApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomUrlbytes");
+                throw new VaultApiException(400, "Missing required parameter 'urlbytes' when calling System->PostSysToolsRandomUrlbytes");
 
 
             RequestOptions requestOptions = new RequestOptions();
@@ -16235,7 +16235,7 @@ namespace Vault.Api
         /// <summary>
         /// Unseal the Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemUnsealRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysUnseal(SystemUnsealRequest systemUnsealRequest = default(SystemUnsealRequest))
@@ -16274,7 +16274,7 @@ namespace Vault.Api
         /// <summary>
         /// Unseal the Vault. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemUnsealRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16315,7 +16315,7 @@ namespace Vault.Api
         /// <summary>
         /// Look up wrapping properties for the given token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingLookupRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysWrappingLookup(SystemWrappingLookupRequest systemWrappingLookupRequest = default(SystemWrappingLookupRequest))
@@ -16354,7 +16354,7 @@ namespace Vault.Api
         /// <summary>
         /// Look up wrapping properties for the given token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingLookupRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16395,7 +16395,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotates a response-wrapped token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingRewrapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysWrappingRewrap(SystemWrappingRewrapRequest systemWrappingRewrapRequest = default(SystemWrappingRewrapRequest))
@@ -16434,7 +16434,7 @@ namespace Vault.Api
         /// <summary>
         /// Rotates a response-wrapped token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingRewrapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16475,7 +16475,7 @@ namespace Vault.Api
         /// <summary>
         /// Unwraps a response-wrapped token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingUnwrapRequest"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysWrappingUnwrap(SystemWrappingUnwrapRequest systemWrappingUnwrapRequest = default(SystemWrappingUnwrapRequest))
@@ -16514,7 +16514,7 @@ namespace Vault.Api
         /// <summary>
         /// Unwraps a response-wrapped token. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="systemWrappingUnwrapRequest"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
@@ -16555,7 +16555,7 @@ namespace Vault.Api
         /// <summary>
         /// Response-wraps an arbitrary JSON object. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <returns>ApiResponse of Object(void)</returns>
         public ApiResponse<Object> PostSysWrappingWrap()
         {
@@ -16591,7 +16591,7 @@ namespace Vault.Api
         /// <summary>
         /// Response-wraps an arbitrary JSON object. 
         /// </summary>
-        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <exception cref="VaultApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
         public async Task<ApiResponse<Object>> PostSysWrappingWrapAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Vault/Client/ApiClient.cs
+++ b/src/Vault/Client/ApiClient.cs
@@ -142,7 +142,7 @@ namespace Vault.Client
             }
             catch (Exception e)
             {
-                throw new ApiException(500, e.Message);
+                throw new VaultApiException(500, e.Message);
             }
         }
 

--- a/src/Vault/Client/ApiException.cs
+++ b/src/Vault/Client/ApiException.cs
@@ -15,7 +15,7 @@ namespace Vault.Client
     /// <summary>
     /// API Exception
     /// </summary>
-    public class ApiException : Exception
+    public class VaultApiException : Exception
     {
         /// <summary>
         /// Gets or sets the error code (HTTP status code)
@@ -36,28 +36,28 @@ namespace Vault.Client
         public Multimap<string, string> Headers { get; private set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// Initializes a new instance of the <see cref="VaultApiException"/> class.
         /// </summary>
-        public ApiException() { }
+        public VaultApiException() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// Initializes a new instance of the <see cref="VaultApiException"/> class.
         /// </summary>
         /// <param name="errorCode">HTTP status code.</param>
         /// <param name="message">Error message.</param>
-        public ApiException(int errorCode, string message) : base(message)
+        public VaultApiException(int errorCode, string message) : base(message)
         {
             this.ErrorCode = errorCode;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// Initializes a new instance of the <see cref="VaultApiException"/> class.
         /// </summary>
         /// <param name="errorCode">HTTP status code.</param>
         /// <param name="message">Error message.</param>
         /// <param name="errorContent">Error content.</param>
         /// <param name="headers">HTTP Headers.</param>
-        public ApiException(int errorCode, string message, object errorContent = null, Multimap<string, string> headers = null) : base(message)
+        public VaultApiException(int errorCode, string message, object errorContent = null, Multimap<string, string> headers = null) : base(message)
         {
             this.ErrorCode = errorCode;
             this.ErrorContent = errorContent;

--- a/src/Vault/Client/Configuration.cs
+++ b/src/Vault/Client/Configuration.cs
@@ -52,7 +52,7 @@ namespace Vault.Client
             var status = (int)response.StatusCode;
             if (status >= 400)
             {
-                return new ApiException(status,
+                return new VaultApiException(status,
                     string.Format("Error calling {0}: {1}", methodName, response.RawContent),
                     response.RawContent, response.Headers);
             }


### PR DESCRIPTION
## Description
Removed an unused constructor. Fix an issue where exceptions weren't getting thrown b/c we didn't set the `ExceptionFactory`.

Rename `ApiException` --> `VaultApiException`

Resolves # VAULT 7456

## How has this been tested?
Run `make regen-bin`. Tested in a C# application that exceptions are getting thrown. 

## Don't forget to

- [x] run `make regen`
