### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @hashicorp/vault-devex


### PR DESCRIPTION
## Description

same as https://github.com/hashicorp/vault-client-go/pull/45

automatically add [@hashicorp/vault-devex](https://github.com/orgs/hashicorp/teams/vault-devex) as reviewers on PR creation

Resolves # (issue) N/A

## How has this been tested?
N/A

## Don't forget to

- [ ] ~~run `make regen`~~ not needed
