### PR TITLE
Suppress obsolete warning

### DIFF
--- a/generate/templates/netcore_project.mustache
+++ b/generate/templates/netcore_project.mustache
@@ -20,7 +20,7 @@
     <RepositoryType>git</RepositoryType>{{#releaseNote}}
     <PackageReleaseNotes>{{.}}</PackageReleaseNotes>{{/releaseNote}}{{#packageTags}}
     <PackageTags>{{{.}}}</PackageTags>{{/packageTags}}
-    <NoWarn>CS0612</NoWarn>
+    <NoWarn>CS0612</NoWarn><!-- CS0612 is a warning for obsolete attributes. OpenApi marks all deprecated fields as obsolete making this a very noise warning-->
     {{#nullableReferenceTypes}}
     <Nullable>annotations</Nullable>
     {{/nullableReferenceTypes}}

--- a/src/Vault/Vault.csproj
+++ b/src/Vault/Vault.csproj
@@ -17,7 +17,7 @@
     <RepositoryUrl>https://github.com/GIT_USER_ID/GIT_REPO_ID.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>Minor update</PackageReleaseNotes>
-    <NoWarn>CS0612</NoWarn>
+    <NoWarn>CS0612</NoWarn><!-- CS0612 is a warning for obsolete attributes. OpenApi marks all deprecated fields as obsolete making this a very noise warning-->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Suppress the obsolete warning CS0612. This is a noisy warning b/c anything in the OpenApi spec marked as `deprecated` will mark the corresponding variable obsolete, which results in 700+ warnings. 

Resolves # (issue)

## How has this been tested?
make regen-bin to make sure it builds without warnings

## Don't forget to

- [x] run `make regen`
