### PR TITLE
Add support for TLS

### DIFF
--- a/generate/templates/Configuration.mustache
+++ b/generate/templates/Configuration.mustache
@@ -207,7 +207,22 @@ namespace {{packageName}}.Client
                 Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> ValidateServiceCertficate =
                 delegate (object sender, X509Certificate serviceCertificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
                 {
-                    return serviceCertificate.Equals(TLSConfiguration.ServerCertificate);
+                    if (TLSConfiguration.ServerCertificate != null)
+                    {
+                        return serviceCertificate.Equals(TLSConfiguration.ServerCertificate);
+                    }
+                    else if (TLSConfiguration.ServerCertificateCollection != null)
+                    {
+                        foreach (X509Certificate2 cert in TLSConfiguration.ServerCertificateCollection)
+                        {
+                            if (serviceCertificate.Equals(cert))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return true;
                 };
 
                 httpClientHandler.ClientCertificateOptions = ClientCertificateOption.Manual;

--- a/src/Vault/Client/Configuration.cs
+++ b/src/Vault/Client/Configuration.cs
@@ -70,8 +70,8 @@ namespace Vault.Client
         /// </summary>
         public TLSConfiguration(X509Certificate2 serverCertificate = null,
                                 X509CertificateCollection serverCertificateCollection = null,
-                                    X509Certificate2 clientCertificate = null,
-                                    X509CertificateCollection clientCertificateCollection = null)
+                                X509Certificate2 clientCertificate = null,
+                                X509CertificateCollection clientCertificateCollection = null)
         {
             if (serverCertificate == null && serverCertificateCollection == null)
             {
@@ -197,7 +197,22 @@ namespace Vault.Client
                 Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> ValidateServiceCertficate =
                 delegate (object sender, X509Certificate serviceCertificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
                 {
-                    return serviceCertificate.Equals(TLSConfiguration.ServerCertificate);
+                    if (TLSConfiguration.ServerCertificate != null)
+                    {
+                        return serviceCertificate.Equals(TLSConfiguration.ServerCertificate);
+                    }
+                    else if (TLSConfiguration.ServerCertificateCollection != null)
+                    {
+                        foreach (X509Certificate2 cert in TLSConfiguration.ServerCertificateCollection)
+                        {
+                            if (serviceCertificate.Equals(cert))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return true;
                 };
 
                 httpClientHandler.ClientCertificateOptions = ClientCertificateOption.Manual;


### PR DESCRIPTION
## Description
This allows you to set client and server TLS certificates for mTLS and certificate authentication with Vault. 


```
X509Certificate2 clientCert = new X509Certificate2("path/to/client/cert", "passphrase");
X509Certificate2 serverCert = new X509Certificate2("path/to/client/cert", "passphrase");
TLSConfiguration tlsConfig = new TLSConfiguration(serverCert, clientCert);

Configuration config = new Configuration(basePath: address,
                                                    httpClientHandler: httpClientHandler,
                                                    timeout: TimeSpan.FromSeconds(4),
                                                    retryConfiguration: retryConfig,
                                                    tlsConfiguration: tlsConfig);


```

Resolves #8138

## How has this been tested?

Tested against `vault server -dev-tls`

## Don't forget to

- [x] run `make regen`
