### PR TITLE
Adding small file changes so templates match generated code

### DIFF
--- a/Vault.sln
+++ b/Vault.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault", "src\Vault\Vault.csproj", "{C1FB271E-5057-47D7-B18A-B4A47128BB74}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault", "src\Vault\Vault.csproj", "{95AF9C90-3841-4409-A293-4053329DDF3F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault.Test", "src\Vault.Test\Vault.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C1FB271E-5057-47D7-B18A-B4A47128BB74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C1FB271E-5057-47D7-B18A-B4A47128BB74}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1FB271E-5057-47D7-B18A-B4A47128BB74}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1FB271E-5057-47D7-B18A-B4A47128BB74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95AF9C90-3841-4409-A293-4053329DDF3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95AF9C90-3841-4409-A293-4053329DDF3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95AF9C90-3841-4409-A293-4053329DDF3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95AF9C90-3841-4409-A293-4053329DDF3F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/generate/templates/Client.mustache
+++ b/generate/templates/Client.mustache
@@ -21,7 +21,7 @@ namespace {{packageName}}
         {{/operations}}
         {{/apis}}
         {{/apiInfo}}
-        
+
         private ApiClient _apiClient;
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace {{packageName}}
                 throw new ArgumentNullException("Token cannot be empty");
             }
 
-            _apiClient.SetToken(token);   
+            _apiClient.SetToken(token);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace {{packageName}}
         {
             _apiClient.AddCustomHeaders(headersToAdd);
         }
-        
+
         /// <summary>
         /// Overwrites or adds an existing header
         /// </summary>

--- a/generate/templates/libraries/httpclient/ApiClient.mustache
+++ b/generate/templates/libraries/httpclient/ApiClient.mustache
@@ -240,7 +240,7 @@ namespace {{packageName}}.Client
             {
                 foreach (var header in headersToAdd)
                 {
-                    if(header.Key.StartsWith("X-VAULT"))
+                    if (header.Key.StartsWith("X-VAULT"))
                     {
                         throw new ArgumentException("Header cannot start with \"X-VAULT\"");
                     }
@@ -248,7 +248,7 @@ namespace {{packageName}}.Client
                 }
             }
         }
-        
+
         /// <summary>
         /// Adds a KeyValuePair to the current list of custom headers.
         /// If it already exists it will be overwritten
@@ -467,7 +467,7 @@ namespace {{packageName}}.Client
 
             if (Configuration.HttpClientHandler != null && response != null)
             {
-                try 
+                try
                 {
                     foreach (Cookie cookie in Configuration.HttpClientHandler.CookieContainer.GetCookies(uri))
                     {
@@ -554,7 +554,7 @@ namespace {{packageName}}.Client
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
-                responseData = (T)(object) await response.Content.ReadAsStreamAsync();
+                responseData = (T)(object)await response.Content.ReadAsStreamAsync();
             }
 
             InterceptResponse(req, response);
@@ -658,7 +658,7 @@ namespace {{packageName}}.Client
         /// <param name="options">The additional request options.</param>
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Get<T>(string path, RequestOptions options)
-        {            
+        {
             return Exec<T>(NewRequest(HttpMethod.Get, path, options));
         }
 


### PR DESCRIPTION
## Description
Fixing formatting issues in the templates that are causing diffs and breaking ci

Resolves # (8751)

## How has this been tested?

These are all formatting changes. Just tested the project builds

## Don't forget to

- [x] run `make regen`
