### PR TITLE
Github Action to Publish Nuget Package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/setup-dotnet@v2
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.5
-      - name: Create Nuget Package
+      - name: Create NuGet Package
         run: dotnet pack -c Release -p:PackageVersion=${{ github.event.release.tag_name }} --include-symbols
       - name: Add Artifactory Source
         run: |
           nuget sources add -name Artifactory -source ${{ secrets.ARTIFACTORY_REPO_URL }} -username ${{ secrets.ARTIFACTORY_USER_NAME }} -password ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - name: Push Nuget Package
+      - name: Push NuGet Package
         run: nuget push **/*.nupkg -src Artifactory


### PR DESCRIPTION
## Description
This will push a Nuget Package when a release is created to an internal Nuget feed hosted in Artifactory

Resolves # (7281)

## How has this been tested?

Tested by creating a release and checking the nuget package was available in Artifactory

## Don't forget to

- [ ] run `make regen`
