### PR TITLE
Remove Api Warnings

### DIFF
--- a/generate/templates/ApiException.mustache
+++ b/generate/templates/ApiException.mustache
@@ -29,11 +29,6 @@ namespace {{packageName}}.Client
         public IEnumerable<string> ApiErrors { get; private set; }
 
         /// <summary>
-        /// Gets or sets the list of Api Errors
-        /// </summary>
-        public IEnumerable<string> ApiWarnings { get; private set; }
-
-        /// <summary>
         /// Gets or sets the HTTP headers
         /// </summary>
         /// <value>HTTP headers</value>
@@ -74,11 +69,6 @@ namespace {{packageName}}.Client
                 if (structured.ContainsKey("errors"))
                 {
                     this.ApiErrors = structured["errors"];
-                }
-
-                if (structured.ContainsKey("warnings"))
-                {
-                    this.ApiWarnings = structured["warnings"];
                 }
             }
             catch

--- a/src/Vault/Client/ApiException.cs
+++ b/src/Vault/Client/ApiException.cs
@@ -37,11 +37,6 @@ namespace Vault.Client
         public IEnumerable<string> ApiErrors { get; private set; }
 
         /// <summary>
-        /// Gets or sets the list of Api Errors
-        /// </summary>
-        public IEnumerable<string> ApiWarnings { get; private set; }
-
-        /// <summary>
         /// Gets or sets the HTTP headers
         /// </summary>
         /// <value>HTTP headers</value>
@@ -82,11 +77,6 @@ namespace Vault.Client
                 if (structured.ContainsKey("errors"))
                 {
                     this.ApiErrors = structured["errors"];
-                }
-
-                if (structured.ContainsKey("warnings"))
-                {
-                    this.ApiWarnings = structured["warnings"];
                 }
             }
             catch


### PR DESCRIPTION
## Description
Remove Api Warnings. This is implemented incorrectly and there are no Api Warnings in the error response


## How has this been tested?

local testing to make sure exceptions still work

## Don't forget to

- [x] run `make regen`
