### PR TITLE
Remove api endpoint table

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Task<VaultResponse<Object>> unwrappedResp = await vauClient.UnwrapAsync<Object>(
 
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
+
 - [Auth](docs/Auth.md)
 - [Identity](docs/Identity.md)
 - [Secrets](docs/Secrets.md)

--- a/generate/templates/README.mustache
+++ b/generate/templates/README.mustache
@@ -248,6 +248,7 @@ Task<VaultResponse<Object>> unwrappedResp = await vauClient.UnwrapAsync<Object>(
 
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
+
 - [Auth](docs/Auth.md)
 - [Identity](docs/Identity.md)
 - [Secrets](docs/Secrets.md)


### PR DESCRIPTION
## Description
Removing the big generated endpoint table from the end of the `ReadMe` to make it easier to read

## How has this been tested?
Looked at the ReadMe....
