### PR TITLE
Exception UX changes

### DIFF
--- a/Vault.sln
+++ b/Vault.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault", "src\Vault\Vault.csproj", "{EBB0E494-4AE2-44B3-B8D2-8DD2AD692655}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault", "src\Vault\Vault.csproj", "{D4DA54BE-466F-4C98-8E11-E05C1BE9EBF9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault.Test", "src\Vault.Test\Vault.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EBB0E494-4AE2-44B3-B8D2-8DD2AD692655}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EBB0E494-4AE2-44B3-B8D2-8DD2AD692655}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EBB0E494-4AE2-44B3-B8D2-8DD2AD692655}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EBB0E494-4AE2-44B3-B8D2-8DD2AD692655}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4DA54BE-466F-4C98-8E11-E05C1BE9EBF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4DA54BE-466F-4C98-8E11-E05C1BE9EBF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4DA54BE-466F-4C98-8E11-E05C1BE9EBF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4DA54BE-466F-4C98-8E11-E05C1BE9EBF9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/generate/templates/ApiException.mustache
+++ b/generate/templates/ApiException.mustache
@@ -18,12 +18,6 @@ namespace {{packageName}}.Client
         public int StatusCode { get; private set; }
 
         /// <summary>
-        /// Gets or sets the error content (body json object)
-        /// </summary>
-        /// <value>The error content (Http response body).</value>
-        public object ErrorContent { get; private set; }
-
-        /// <summary>
         /// Gets or sets the list of Api Errors
         /// </summary>
         public IEnumerable<string> Errors { get; private set; }
@@ -59,7 +53,6 @@ namespace {{packageName}}.Client
         public {{packageName}}ApiException(int statusCode, string message, string errorContent, Multimap<string, string> headers = null) : base(message)
         {
             this.StatusCode = statusCode;
-            this.ErrorContent = errorContent;
             this.Headers = headers;
 
             try
@@ -73,7 +66,9 @@ namespace {{packageName}}.Client
             }
             catch
             {
-                // Ignore
+                // With a deserialization exception we set the full 
+                // error content to the first element
+                this.Errors = new List<string>() { errorContent };
             }
         }
     }

--- a/src/Vault/Client/ApiException.cs
+++ b/src/Vault/Client/ApiException.cs
@@ -26,12 +26,6 @@ namespace Vault.Client
         public int StatusCode { get; private set; }
 
         /// <summary>
-        /// Gets or sets the error content (body json object)
-        /// </summary>
-        /// <value>The error content (Http response body).</value>
-        public object ErrorContent { get; private set; }
-
-        /// <summary>
         /// Gets or sets the list of Api Errors
         /// </summary>
         public IEnumerable<string> Errors { get; private set; }
@@ -67,7 +61,6 @@ namespace Vault.Client
         public VaultApiException(int statusCode, string message, string errorContent, Multimap<string, string> headers = null) : base(message)
         {
             this.StatusCode = statusCode;
-            this.ErrorContent = errorContent;
             this.Headers = headers;
 
             try
@@ -81,7 +74,9 @@ namespace Vault.Client
             }
             catch
             {
-                // Ignore
+                // With a deserialization exception we set the full 
+                // error content to the first element
+                this.Errors = new List<string>() { errorContent };
             }
         }
     }


### PR DESCRIPTION
## Description
Per a previous [PR](https://github.com/hashicorp/vault-client-dotnet/pull/67), updating some UX related Exception issues. Namely:
- Rename `ApiErrors` to `Errors`
- Remove `ErrorContent`
- Set `ErrorContent` to be the first element in `Errors` if we fail to deserialize

Resolves # [VAULT-12148]

## How has this been tested?

Locally tested with exceptions



[VAULT-12148]: https://hashicorp.atlassian.net/browse/VAULT-12148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ