### PR TITLE
Switch to IDictionary objects for public functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ vaultClient.ClearNamespace();
 The Vault client also allows for adding custom headers that will be applied to every request.
 
 ```csharp
-var myCustomHeaders = new Dictionary<string, string> 
+IDictionary<string, string> myCustomHeaders = new Dictionary<string, string> 
 {
     { "my-custom-header", "myHeaders"}    
 };

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Each generic operation has a synchronous and asynchronous version.
 ```csharp
 // Generic read from a path with query parameters
 var readPath = "/some/path"
-Dictionary<string, object> queryParams = new Dictionary<string, object>
+IDictionary<string, object> queryParams = new Dictionary<string, object>
 {
     {"key", "value"}
 };
@@ -254,7 +254,7 @@ VaultResponse<Object> resp = await vaultClient.ReadAsync<Object>(myPath, queryPa
 
 // Generic write to a path
 var writePath = "/some/other/path";
-Dictionary<string, object>  secretData = new Dictionary<string, object>
+IDictionary<string, object>  secretData = new Dictionary<string, object>
     {
         {"1", "1"},
         {"2", 2},

--- a/Vault.sln
+++ b/Vault.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault", "src\Vault\Vault.csproj", "{B6B3CB89-D3AD-4E80-B6BE-5951B472560E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault", "src\Vault\Vault.csproj", "{291D1ED7-CD79-4AC4-A195-38D48A55DBA4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vault.Test", "src\Vault.Test\Vault.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B6B3CB89-D3AD-4E80-B6BE-5951B472560E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B6B3CB89-D3AD-4E80-B6BE-5951B472560E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B6B3CB89-D3AD-4E80-B6BE-5951B472560E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B6B3CB89-D3AD-4E80-B6BE-5951B472560E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{291D1ED7-CD79-4AC4-A195-38D48A55DBA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{291D1ED7-CD79-4AC4-A195-38D48A55DBA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{291D1ED7-CD79-4AC4-A195-38D48A55DBA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{291D1ED7-CD79-4AC4-A195-38D48A55DBA4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/generate/templates/Client.mustache
+++ b/generate/templates/Client.mustache
@@ -112,7 +112,7 @@ namespace {{packageName}}
         /// <summary>
         /// Adds a dictionary of custom headers to current list of custom headers
         /// </summary>
-        public void AddCustomHeaders(Dictionary<string, string> headersToAdd)
+        public void AddCustomHeaders(IDictionary<string, string> headersToAdd)
         {
             _apiClient.AddCustomHeaders(headersToAdd);
         }
@@ -155,7 +155,7 @@ namespace {{packageName}}
         /// <param name="path">Path to read from</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public VaultResponse<T> Read<T>(string path, Dictionary<string, object> queryParameters = null)
+        public VaultResponse<T> Read<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             return ReadAsync<T>(path, queryParameters).GetAwaiter().GetResult();
         }
@@ -165,7 +165,7 @@ namespace {{packageName}}
         /// <param name="path">Path to read from</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public async Task<VaultResponse<T>> ReadAsync<T>(string path, Dictionary<string, object> queryParameters = null)
+        public async Task<VaultResponse<T>> ReadAsync<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path", "Cannot be null or empty");
 
@@ -188,7 +188,7 @@ namespace {{packageName}}
         /// <param name="path">Path to write to</param>
         /// <param name="data">Data to be written</param>
         /// </summary>
-        public VaultResponse<T> Write<T>(string path, Dictionary<string, object> data)
+        public VaultResponse<T> Write<T>(string path, IDictionary<string, object> data)
         {
             return WriteAsync<T>(path, data).GetAwaiter().GetResult();
         }
@@ -198,7 +198,7 @@ namespace {{packageName}}
         /// <param name="path">Path to write to</param>
         /// <param name="data">Data to be written</param>
         /// </summary>
-        public async Task<VaultResponse<T>> WriteAsync<T>(string path, Dictionary<string, object> data)
+        public async Task<VaultResponse<T>> WriteAsync<T>(string path, IDictionary<string, object> data)
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path", "Cannot be null or empty");
 
@@ -217,7 +217,7 @@ namespace {{packageName}}
         /// <param name="path">Path to delete at</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public VaultResponse<T> Delete<T>(string path, Dictionary<string, object> queryParameters = null)
+        public VaultResponse<T> Delete<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             return DeleteAsync<T>(path, queryParameters).GetAwaiter().GetResult();
         }
@@ -227,7 +227,7 @@ namespace {{packageName}}
         /// <param name="path">Path to delete at</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public async Task<VaultResponse<T>> DeleteAsync<T>(string path, Dictionary<string, object> queryParameters = null)
+        public async Task<VaultResponse<T>> DeleteAsync<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path", "Cannot be null or empty");
 

--- a/generate/templates/ClientUtils.mustache
+++ b/generate/templates/ClientUtils.mustache
@@ -104,9 +104,9 @@ namespace {{packageName}}.Client
         /// <summary>
         /// Convert a dictionary 
         /// Used to create a multimap of parameters
-        /// <param name="dictionary">Dictionary of parameters to convert to multimap</param>
+        /// <param name="dictionary">IDictionary of parameters to convert to multimap</param>
         /// </summary>
-        public static Multimap<string, string> DictionaryToMultimap(Dictionary<string, object> dictionary)
+        public static Multimap<string, string> DictionaryToMultimap(IDictionary<string, object> dictionary)
         {
             var parameters = new Multimap<string, string>();
             foreach (KeyValuePair<string, object> entry in dictionary)

--- a/generate/templates/libraries/httpclient/ApiClient.mustache
+++ b/generate/templates/libraries/httpclient/ApiClient.mustache
@@ -165,7 +165,7 @@ namespace {{packageName}}.Client
 
         public int ResponseWrapTTL = 0;
 
-        public Dictionary<string, string> CustomHeaders = new Dictionary<string, string> { };
+        public IDictionary<string, string> CustomHeaders = new Dictionary<string, string> { };
     }
 
     /// <summary>
@@ -252,7 +252,7 @@ namespace {{packageName}}.Client
         /// <summary>
         /// Adds a dictionary of custom headers to current list of custom headers.
         /// </summary>
-        internal void AddCustomHeaders(Dictionary<string, string> headersToAdd)
+        internal void AddCustomHeaders(IDictionary<string, string> headersToAdd)
         {
             lock (_requestHeaderLock)
             {

--- a/src/Vault/Client/ApiClient.cs
+++ b/src/Vault/Client/ApiClient.cs
@@ -164,7 +164,7 @@ namespace Vault.Client
 
         public int ResponseWrapTTL = 0;
 
-        public Dictionary<string, string> CustomHeaders = new Dictionary<string, string> { };
+        public IDictionary<string, string> CustomHeaders = new Dictionary<string, string> { };
     }
 
     /// <summary>
@@ -251,7 +251,7 @@ namespace Vault.Client
         /// <summary>
         /// Adds a dictionary of custom headers to current list of custom headers.
         /// </summary>
-        internal void AddCustomHeaders(Dictionary<string, string> headersToAdd)
+        internal void AddCustomHeaders(IDictionary<string, string> headersToAdd)
         {
             lock (_requestHeaderLock)
             {

--- a/src/Vault/Client/ClientUtils.cs
+++ b/src/Vault/Client/ClientUtils.cs
@@ -91,9 +91,9 @@ namespace Vault.Client
         /// <summary>
         /// Convert a dictionary 
         /// Used to create a multimap of parameters
-        /// <param name="dictionary">Dictionary of parameters to convert to multimap</param>
+        /// <param name="dictionary">IDictionary of parameters to convert to multimap</param>
         /// </summary>
-        public static Multimap<string, string> DictionaryToMultimap(Dictionary<string, object> dictionary)
+        public static Multimap<string, string> DictionaryToMultimap(IDictionary<string, object> dictionary)
         {
             var parameters = new Multimap<string, string>();
             foreach (KeyValuePair<string, object> entry in dictionary)

--- a/src/Vault/VaultClient.cs
+++ b/src/Vault/VaultClient.cs
@@ -122,7 +122,7 @@ namespace Vault
         /// <summary>
         /// Adds a dictionary of custom headers to current list of custom headers
         /// </summary>
-        public void AddCustomHeaders(Dictionary<string, string> headersToAdd)
+        public void AddCustomHeaders(IDictionary<string, string> headersToAdd)
         {
             _apiClient.AddCustomHeaders(headersToAdd);
         }
@@ -165,7 +165,7 @@ namespace Vault
         /// <param name="path">Path to read from</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public VaultResponse<T> Read<T>(string path, Dictionary<string, object> queryParameters = null)
+        public VaultResponse<T> Read<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             return ReadAsync<T>(path, queryParameters).GetAwaiter().GetResult();
         }
@@ -175,7 +175,7 @@ namespace Vault
         /// <param name="path">Path to read from</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public async Task<VaultResponse<T>> ReadAsync<T>(string path, Dictionary<string, object> queryParameters = null)
+        public async Task<VaultResponse<T>> ReadAsync<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path", "Cannot be null or empty");
 
@@ -198,7 +198,7 @@ namespace Vault
         /// <param name="path">Path to write to</param>
         /// <param name="data">Data to be written</param>
         /// </summary>
-        public VaultResponse<T> Write<T>(string path, Dictionary<string, object> data)
+        public VaultResponse<T> Write<T>(string path, IDictionary<string, object> data)
         {
             return WriteAsync<T>(path, data).GetAwaiter().GetResult();
         }
@@ -208,7 +208,7 @@ namespace Vault
         /// <param name="path">Path to write to</param>
         /// <param name="data">Data to be written</param>
         /// </summary>
-        public async Task<VaultResponse<T>> WriteAsync<T>(string path, Dictionary<string, object> data)
+        public async Task<VaultResponse<T>> WriteAsync<T>(string path, IDictionary<string, object> data)
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path", "Cannot be null or empty");
 
@@ -227,7 +227,7 @@ namespace Vault
         /// <param name="path">Path to delete at</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public VaultResponse<T> Delete<T>(string path, Dictionary<string, object> queryParameters = null)
+        public VaultResponse<T> Delete<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             return DeleteAsync<T>(path, queryParameters).GetAwaiter().GetResult();
         }
@@ -237,7 +237,7 @@ namespace Vault
         /// <param name="path">Path to delete at</param>
         /// <param name="queryParameters">Optional dictionary of query parameters</param>
         /// </summary>
-        public async Task<VaultResponse<T>> DeleteAsync<T>(string path, Dictionary<string, object> queryParameters = null)
+        public async Task<VaultResponse<T>> DeleteAsync<T>(string path, IDictionary<string, object> queryParameters = null)
         {
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path", "Cannot be null or empty");
 


### PR DESCRIPTION
## Description

`IDictionary` is a public interface for a `Dictionary` which does not assume a specific internal implementation, which seems better suited for our public functions.

## How has this been tested?

```sh
make regen && make build
```

