### PR TITLE
Fixing symbol package failing to push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.5
       - name: Create NuGet Package
-        run: dotnet pack -c Release -p:PackageVersion=${{ github.event.release.tag_name }} --include-symbols
+        run: dotnet pack -c Release -p:PackageVersion=${{ github.event.release.tag_name }} --include-symbols  -p:SymbolPackageFormat=snupkg
       - name: Push NuGet Package
         run: nuget push **/*.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -src https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Description
The Nuget package pushes fine, but the symbols package is failing. There is a new symbol file format that we should be using that avoids these collisions.

For more context: [here](https://devblogs.microsoft.com/nuget/improved-package-debugging-experience-with-the-nuget-org-symbol-server/)

## How has this been tested?
Was able to pack this locally and will double check that it works w/ the next release. 