### PR TITLE
Fix warnings during generation

### DIFF
--- a/generate/templates/api_doc.handlebars
+++ b/generate/templates/api_doc.handlebars
@@ -5,7 +5,7 @@ All URIs are relative to *{{{basePath}}}*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-{{#with operations}}{{#each operation}}{{#endsWith operationId "2"}}{{else}}{{#endsWith operationId "3"}}{{else}}[**{{operationId}}**]({{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}}
+{{#with operations}}{{#each operation}}{{#endsWith operationId "2"}}{{else}}{{#endsWith operationId "3"}}{{else}}[**{{operationId}}**]({{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{#if summary}}{{summary}}{{/if}}
 {{/endsWith}}{{/endsWith}}{{/each}}{{/with}}
 
 {{#with operations}}
@@ -13,9 +13,9 @@ Method | HTTP request | Description
 <a name="{{{operationIdLowerCase}}}"></a>
 # **{{{operationId}}}**
 
-> {{returnType}}{{#unless returnType}}void{{/unless}} {{operationId}} ({{#each pathParams}}{{#with required}}{{{dataType}}} {{paramName}}, {{/with}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#unless required}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/unless}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null)
+> {{#with returnType}}{{.}}{{else}}void{{/with}} {{operationId}} ({{#each pathParams}}{{#with required}}{{{dataType}}} {{paramName}}, {{/with}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#unless required}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/unless}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null)
 
-{{{summary}}}{{#if notes}}
+{{#if summary}}{{{summary}}}{{/if}}{{#if notes}}
 
 {{{.}}}{{/if}}
 
@@ -73,10 +73,10 @@ namespace Example
             {{/unless}}
             {{#each allParams}}
             {{#if isPrimitiveType}}
-            var {{paramName}} = {{{example}}};  // {{{dataType}}} | {{{description}}}{{#unless required}} (optional) {{/unless}}{{#with defaultValue}} (default to {{{.}}}){{/with}}
+            var {{paramName}} = {{{example}}};  // {{{dataType}}} | {{#if description}}{{{description}}}{{/if}}{{#unless required}} (optional) {{/unless}}{{#with defaultValue}} (default to {{{.}}}){{/with}}
             {{/if}}
             {{#unless isPrimitiveType}}
-            var {{paramName}} = new {{{dataType}}}(); // {{{dataType}}} | {{{description}}}{{#unless required}} (optional) {{/unless}}{{#with defaultValue}} (default to {{{.}}}){{/with}}
+            var {{paramName}} = new {{{dataType}}}(); // {{{dataType}}} | {{#if description}}{{{description}}}{{/if}}{{#unless required}} (optional) {{/unless}}{{#with defaultValue}} (default to {{{.}}}){{/with}}
             {{/unless}}
             {{/each}}
 
@@ -104,7 +104,7 @@ namespace Example
 {{#unless allParams}}This endpoint does not need any parameter.{{/unless}}{{#each allParams}}{{#if @last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/if}}{{/each}}
-{{#each allParams}} **{{paramName}}** | {{#if isFile}}**{{dataType}}**{{/if}}{{#if isPrimitiveType}}**{{dataType}}**{{/if}}{{#unless isPrimitiveType}}{{#unless isFile}}[**{{dataType}}**]({{#if isContainer}}{{baseType}}{{/if}}{{#unless isContainer}}{{dataType}}{{/unless}}.md){{/unless}}{{/unless}}| {{description}} | {{#unless required}}[optional] {{/unless}}{{#with defaultValue}}[default to {{.}}]{{/with}}
+{{#each allParams}} **{{paramName}}** | {{#if isFile}}**{{dataType}}**{{/if}}{{#if isPrimitiveType}}**{{dataType}}**{{/if}}{{#unless isPrimitiveType}}{{#unless isFile}}[**{{dataType}}**]({{#if isContainer}}{{baseType}}{{/if}}{{#unless isContainer}}{{dataType}}{{/unless}}.md){{/unless}}{{/unless}}| {{#if description}}{{description}}{{/if}} | {{#unless required}}[optional] {{/unless}}{{#with defaultValue}}[default to {{.}}]{{/with}}
 {{/each}}
 
 ### Return type
@@ -117,8 +117,8 @@ Name | Type | Description  | Notes
 
 ### HTTP request headers
 
- - **Content-Type**: {{#if consumes}}{{{mediaType}}}{{#unless @last}}, {{/unless}}{{/if}}{{#unless consumes}}Not defined{{/unless}}
- - **Accept**: {{#each produces}}{{{mediaType}}}{{#unless @last}}, {{/unless}}{{/each}}{{#unless produces}}Not defined{{/unless}}
+ - **Content-Type**: {{#if consumes}}{{#if mediaType}}{{{mediaType}}}{{/if}}{{#unless @last}}, {{/unless}}{{/if}}{{#unless consumes}}Not defined{{/unless}}
+ - **Accept**: {{#each produces}}{{#if mediaType}}{{{mediaType}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}}{{#unless produces}}Not defined{{/unless}}
 
 {{#with responses.[0]}}
 
@@ -126,7 +126,7 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 {{#each responses}}
-| **{{code}}** | {{message}} | {{#each headers}} * {{baseName}} - {{description}} <br> {{/each}}{{#unless headers.[0]}} - {{/unless}} |
+| **{{code}}** | {{message}} | {{#each headers}} * {{baseName}} - {{#if description}}{{description}}{{/if}} <br> {{/each}}{{#unless headers.[0]}} - {{/unless}} |
 {{/each}}
 {{/with}}
 

--- a/generate/templates/libraries/httpclient/api.handlebars
+++ b/generate/templates/libraries/httpclient/api.handlebars
@@ -17,19 +17,19 @@ namespace {{packageName}}.{{apiPackage}}
         #region Synchronous Operations
         {{#each operation}}{{#endsWith operationId "2"}}{{else}}{{#endsWith operationId "3"}}{{else}}
         /// <summary>
-        /// {{summary}}
+        /// {{#if summary}}{{summary}}{{/if}}
         /// </summary>
         /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#if bodyParam}}{{~#with bodyParam ~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/with}}{{/if ~}}
         {{#if pathParams}}{{#each pathParams~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/each ~}}{{/if ~}}
         {{#if queryParams}}{{#each queryParams ~}}{{#unless required}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/unless}}{{/each}}{{/if ~}}
-        /// <returns>VaultResponse of {{returnType}}{{#unless returnType}}Object(void){{/unless}}</returns>
+        /// <returns>VaultResponse of {{#with returnType}}{{.}}{{else}}Object(void){{/with}}</returns>
         /// <param name="wrapTTL">
         /// Sets the X-Vault-Wrap-TTL Header
         /// <remarks>
@@ -40,7 +40,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#if isDeprecated}}
         [Obsolete]
         {{/if ~}}
-        VaultResponse<{{{returnType}}}{{#unless returnType}}Object{{/unless}}> {{operationId}}({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null);
+        VaultResponse<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}> {{operationId}}({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null);
         {{/endsWith}}{{/endsWith}}{{/each}}
         #endregion Synchronous Operations
     }
@@ -54,17 +54,17 @@ namespace {{packageName}}.{{apiPackage}}
         #region Asynchronous Operations
         {{#each operation}}{{#endsWith operationId "2"}}{{else}}{{#endsWith operationId "3"}}{{else}}
         /// <summary>
-        /// {{summary}}
+        /// {{#if summary}}{{summary}}{{/if}}
         /// </summary>
         /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#if bodyParam}}{{~#with bodyParam ~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/with}}{{/if ~}}
         {{#if pathParams}}{{#each pathParams~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/each ~}}{{/if ~}}
         {{#if queryParams}}{{#each queryParams ~}}{{#unless required}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/unless}}{{/each}}{{/if ~}}
         /// <param name="wrapTTL">
         /// Sets the X-Vault-Wrap-TTL Header
@@ -78,7 +78,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#if isDeprecated}}
         [Obsolete]
         {{/if ~}}
-        Task<VaultResponse<{{{returnType}}}{{#unless returnType}}Object{{/unless}}>> {{operationId}}Async({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<VaultResponse<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}>> {{operationId}}Async({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null, CancellationToken cancellationToken = default(CancellationToken));
         {{/endsWith}}{{/endsWith}}{{/each}}
         #endregion Asynchronous Operations
     }
@@ -154,19 +154,19 @@ namespace {{packageName}}.{{apiPackage}}
 
         {{#each operation}}{{#endsWith operationId "2"}}{{else}}{{#endsWith operationId "3"}}{{else}}
         /// <summary>
-        /// {{summary}} {{notes}}
+        /// {{#if summary}}{{summary}}{{/if}} {{#if notes}}{{notes}}{{/if}}
         /// </summary>
         /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#if bodyParam}}{{~#with bodyParam ~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/with}}{{/if ~}}
         {{#if pathParams}}{{#each pathParams~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/each ~}}{{/if ~}}
         {{#if queryParams}}{{#each queryParams ~}}{{#unless required}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/unless}}{{/each}}{{/if ~}}
-        /// <returns>VaultResponse of {{returnType}}{{#unless returnType}}Object(void){{/unless}}</returns>
+        /// <returns>VaultResponse of {{#with returnType}}{{.}}{{else}}Object(void){{/with}}</returns>
         /// <param name="wrapTTL">
         /// Sets the X-Vault-Wrap-TTL Header
         /// <remarks>
@@ -177,7 +177,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#if isDeprecated}}
         [Obsolete]
         {{/if ~}}
-        public VaultResponse<{{{returnType}}}{{#unless returnType}}Object{{/unless}}> {{operationId}}({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null)
+        public VaultResponse<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}> {{operationId}}({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null)
         {
             {{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{#unless vendorExtensions.x-csharp-value-type}}
             // verify the required parameter '{{paramName}}' is set
@@ -197,12 +197,12 @@ namespace {{packageName}}.{{apiPackage}}
             }
 
             string[] _contentTypes = new string[] {
-                {{#if consumes}}"{{{mediaType}}}"{{#unless @last}},{{/unless}}{{/if}}
+                {{#if consumes}}"{{#if mediaType}}{{{mediaType}}}{{/if}}"{{#unless @last}},{{/unless}}{{/if}}
             };
 
             // to determine the Accept header
             string[] _accepts = new string[] {
-                {{#each produces}}"{{{mediaType}}}"{{#unless @last}},{{/unless}}{{/each}}
+                {{#each produces}}"{{#if mediaType}}{{{mediaType}}}{{/if}}"{{#unless @last}},{{/unless}}{{/each}}
             };
 
             var contentType = ClientUtils.SelectHeaderContentType(_contentTypes);
@@ -220,7 +220,7 @@ namespace {{packageName}}.{{apiPackage}}
                 requestOptions.PathParameters.Add("{{baseName}}", ClientUtils.ParameterToString({{paramName}})); // path parameter
             }{{/unless}}{{/each}}
             {{#each queryParams}}{{#with required}}
-            requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", "true"));
+            requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{#if collectionFormat}}{{collectionFormat}}{{/if}}", "{{baseName}}", "true"));
             {{/with}}
             {{#unless required}}
             if ({{paramName}} != null)
@@ -228,13 +228,13 @@ namespace {{packageName}}.{{apiPackage}}
                 {{#if isDeepObject}}{{#each items.vars}}
                 if ({{paramName}}.{{name}} != null)
                 {
-                    requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}.{{name}}));
+                    requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{#if collectionFormat}}{{collectionFormat}}{{/if}}", "{{baseName}}", {{paramName}}.{{name}}));
                 }{{/each}}
                 {{#unless items}}
                 requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
                 {{/unless}}{{/if}}
                 {{#unless isDeepObject}}
-                requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
+                requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{#if collectionFormat}}{{collectionFormat}}{{/if}}", "{{baseName}}", {{paramName}}));
                 {{/unless}}
             }{{/unless}}{{/each}}
             {{#each headerParams}}{{#with required}}
@@ -251,7 +251,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/with}}
 
             // make the HTTP request
-            var response = this.Client.{{capitalize (lower httpMethod)}}<{{{returnType}}}{{#unless returnType}}Object{{/unless}}>("{{{path}}}", requestOptions);
+            var response = this.Client.{{capitalize (lower httpMethod)}}<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}>("{{{path}}}", requestOptions);
 
             if (this.ExceptionFactory != null)
             {
@@ -259,22 +259,22 @@ namespace {{packageName}}.{{apiPackage}}
                 if (exception != null) throw exception;
             }
 
-            return ClientUtils.ToVaultResponse<{{{returnType}}}{{#unless returnType}}Object{{/unless}}>(response.RawContent);
+            return ClientUtils.ToVaultResponse<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}>(response.RawContent);
         }
 
         {{#if supportsAsync}}
         /// <summary>
-        /// {{summary}} {{notes}}
+        /// {{#if summary}}{{summary}}{{/if}} {{#if notes}}{{notes}}{{/if}}
         /// </summary>
         /// <exception cref="{{packageName}}ApiException">Thrown when fails to make API call</exception>
         {{#if bodyParam}}{{~#with bodyParam ~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/with}}{{/if ~}}
         {{#if pathParams}}{{#each pathParams~}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/each ~}}{{/if ~}}
         {{#if queryParams}}{{#each queryParams ~}}{{#unless required}}
-        /// <param name="{{paramName}}">{{description}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
+        /// <param name="{{paramName}}">{{#if description}}{{description}}{{/if}}{{#unless required}} (optional{{#with defaultValue}}, default to {{.}}{{/with}}){{/unless}}{{#if isDeprecated}} (deprecated){{/if}}</param>
         {{/unless}}{{/each}}{{/if ~}}
         /// <param name="wrapTTL">
         /// Sets the X-Vault-Wrap-TTL Header
@@ -288,7 +288,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#if isDeprecated}}
         [Obsolete]
         {{/if ~}}
-        public async Task<VaultResponse<{{{returnType}}}{{#unless returnType}}Object{{/unless}}>> {{operationId}}Async({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<VaultResponse<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}>> {{operationId}}Async({{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{{dataType}}} {{paramName}}, {{/endsWith}}{{/each}}{{#with bodyParam}}{{{dataType}}} {{{paramName}}}, {{/with}}{{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{{dataType}}} {{paramName}}{{#if optionalMethodArgument}} = {{#with defaultValue}}{{{.}}}{{/with}}{{/if}}, {{/endsWith}}{{/each}}{{#each queryParams}}{{#unless required}}{{{dataType}}} {{paramName}} = default({{{dataType}}}), {{/unless}}{{/each}}TimeSpan? wrapTTL = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             {{#each pathParams}}{{#endsWith baseName "_mount_path"}}{{else}}{{#unless vendorExtensions.x-csharp-value-type}}
             // verify the required parameter '{{paramName}}' is set
@@ -309,12 +309,12 @@ namespace {{packageName}}.{{apiPackage}}
             }
 
             string[] _contentTypes = new string[] {
-                {{#if consumes}}"{{{mediaType}}}"{{#unless @last}}, {{/unless}}{{/if}}
+                {{#if consumes}}"{{#if mediaType}}{{{mediaType}}}{{/if}}"{{#unless @last}}, {{/unless}}{{/if}}
             };
 
             // to determine the Accept header
             string[] _accepts = new string[] {
-                {{#each produces}}"{{{mediaType}}}"{{#unless @last}},{{/unless}}{{/each}}
+                {{#each produces}}"{{#if mediaType}}{{{mediaType}}}{{/if}}"{{#unless @last}},{{/unless}}{{/each}}
             };
 
             var contentType = ClientUtils.SelectHeaderContentType(_contentTypes);
@@ -332,12 +332,12 @@ namespace {{packageName}}.{{apiPackage}}
                 requestOptions.PathParameters.Add("{{baseName}}", ClientUtils.ParameterToString({{paramName}})); // path parameter
             }{{/unless}}{{/each}}
             {{#each queryParams}}{{#with required}}
-            requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", "true"));
+            requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{#if collectionFormat}}{{collectionFormat}}{{/if}}", "{{baseName}}", "true"));
             {{/with}}
             {{#unless required}}
             if ({{paramName}} != null)
             {
-                requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
+                requestOptions.QueryParameters.Add(ClientUtils.ParameterToMultiMap("{{#if collectionFormat}}{{collectionFormat}}{{/if}}", "{{baseName}}", {{paramName}}));
             }{{/unless}}{{/each}}
             {{#each headerParams}}{{#with required}}
             requestOptions.HeaderParameters.Add("{{baseName}}", ClientUtils.ParameterToString({{paramName}})); // header parameter
@@ -352,7 +352,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/with ~}}
 
             // make the HTTP request
-            var response = await this.AsynchronousClient.{{capitalize (lower httpMethod)}}Async<{{{returnType}}}{{#unless returnType}}Object{{/unless}}>("{{{path}}}", requestOptions, cancellationToken).ConfigureAwait(false);
+            var response = await this.AsynchronousClient.{{capitalize (lower httpMethod)}}Async<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}>("{{{path}}}", requestOptions, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -360,7 +360,7 @@ namespace {{packageName}}.{{apiPackage}}
                 if (exception != null) throw exception;
             }
 
-            return ClientUtils.ToVaultResponse<{{{returnType}}}{{#unless returnType}}Object{{/unless}}>(response.RawContent);
+            return ClientUtils.ToVaultResponse<{{#with returnType}}{{{.}}}{{else}}Object{{/with}}>(response.RawContent);
         }{{/if}}{{/endsWith}}{{/endsWith}}{{/each}}
     }{{/with}}
 }

--- a/generate/templates/modelAnyOf.handlebars
+++ b/generate/templates/modelAnyOf.handlebars
@@ -1,5 +1,5 @@
     /// <summary>
-    /// {{description}}{{#unless description}}{{classname}}{{/unless}}
+    /// {{#with description}}{{.}}{{else}}{{classname}}{{/with}}
     /// </summary>
     [JsonConverter(typeof({{classname}}JsonConverter))]
     [DataContract(Name = "{{{name}}}")]

--- a/generate/templates/modelEnum.handlebars
+++ b/generate/templates/modelEnum.handlebars
@@ -1,5 +1,5 @@
     /// <summary>
-    /// {{description}}{{#unless description}}Defines {{{name}}}{{/unless}}
+    /// {{#with description}}{{.}}{{else}}Defines {{{name}}}{{/with}}
     /// </summary>
     {{#with description}}
     /// <value>{{.}}</value>

--- a/generate/templates/modelGeneric.handlebars
+++ b/generate/templates/modelGeneric.handlebars
@@ -1,5 +1,5 @@
     /// <summary>
-    /// {{description}}{{#unless description}}{{classname}}{{/unless}}
+    /// {{#with description}}{{.}}{{else}}{{classname}}{{/with}}
     /// </summary>
     [DataContract(Name = "{{{name}}}")]
     {{>visibility}} partial class {{classname}} : {{#with parent}}{{{.}}}, {{/with}}IEquatable<{{classname}}>{{#if validatable}}, IValidatableObject{{/if}}
@@ -7,13 +7,13 @@
         {{~#each vars ~}}{{~#with items.isEnum ~}}{{#with items}}{{#unless complexType}}{{>modelInnerEnum}}{{/unless}}{{/with}}{{/with ~}}
         {{~#if isEnum ~}}{{#unless complexType}}{{>modelInnerEnum}}{{/unless}}{{/if ~}}
         {{#if isEnum}}/// <summary>
-        /// {{description}}{{#unless description}}Gets or Sets {{{name}}}{{/unless}}
+        /// {{#with description}}{{.}}{{else}}Gets or Sets {{{name}}}{{/with}}
         /// </summary>
         {{#with description}}/// <value>{{.}}</value>{{/with}}
         {{#unless conditionalSerialization}}
         [DataMember(Name = "{{baseName}}"{{#with required}}, IsRequired = true{{/with}}, EmitDefaultValue = {{#with vendorExtensions.x-emit-default-value}}true{{/with}}{{#unless vendorExtensions.x-emit-default-value}}{{#if isBoolean}}true{{/if}}{{#unless isBoolean}}{{#if isNullable}}true{{/if}}{{#unless isNullable}}false{{/unless}}{{/unless}}{{/unless}})]
         {{#if deprecated ~}}[Obsolete]{{/if ~}}
-        public {{{complexType}}}{{#unless complexType}}{{{datatypeWithEnum}}}{{/unless}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} {{name}} { get; set; }
+        public {{#with complexType}}{{{.}}}{{else}}{{{datatypeWithEnum}}}{{/with}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} {{name}} { get; set; }
         {{#if isReadOnly}}
         /// <summary>
         /// Returns false as {{name}} should not be serialized given that it's read-only.
@@ -26,7 +26,7 @@
         {{#with conditionalSerialization}}{{#if isReadOnly}}
         [DataMember(Name = "{{baseName}}"{{#with required}}, IsRequired = true{{/with}}, EmitDefaultValue = {{#with vendorExtensions.x-emit-default-value}}true{{/with}}{{#unless vendorExtensions.x-emit-default-value}}{{#if isBoolean}}true{{/if}}{{#unless isBoolean}}{{#if isNullable}}true{{/if}}{{#unless isNullable}}false{{/unless}}{{/unless}}{{/unless}})]
         {{#if deprecated ~}}[Obsolete]{{/if ~}}
-        public {{{complexType}}}{{#unless complexType}}{{{datatypeWithEnum}}}{{/unless}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} {{name}} { get; set; }
+        public {{#with complexType}}{{{.}}}{{else}}{{{datatypeWithEnum}}}{{/with}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} {{name}} { get; set; }
 
         /// <summary>
         /// Returns false as {{name}} should not be serialized given that it's read-only.
@@ -39,7 +39,7 @@
 
         {{#unless isReadOnly}}[DataMember(Name = "{{baseName}}"{{#with required}}, IsRequired = true{{/with}}, EmitDefaultValue = {{#with vendorExtensions.x-emit-default-value}}true{{/with}}{{#unless vendorExtensions.x-emit-default-value}}{{#if isBoolean}}true{{/if}}{{#unless isBoolean}}{{#if isNullable}}true{{/if}}{{#unless isNullable}}false{{/unless}}{{/unless}}{{/unless}})]
         {{#if deprecated}}[Obsolete]{{/if ~}}
-        public {{{complexType}}}{{#unless complexType}}{{{datatypeWithEnum}}}{{/unless}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} {{name}}
+        public {{#with complexType}}{{{.}}}{{else}}{{{datatypeWithEnum}}}{{/with}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} {{name}}
         {
             get{ return _{{name}};}
             set
@@ -48,7 +48,7 @@
                 _flag{{name}} = true;
             }
         }
-        private {{{complexType}}}{{#unless complexType}}{{{datatypeWithEnum}}}{{/unless}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} _{{name}};
+        private {{#with complexType}}{{{.}}}{{else}}{{{datatypeWithEnum}}}{{/with}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}} _{{name}};
         private bool _flag{{name}};
 
         /// <summary>
@@ -75,7 +75,7 @@
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.
         /// </summary>
         {{#each readWriteVars}}
-        /// <param name="{{#with lambda.camelcase_param}}{{name}}{{/with}}">{{description}}{{#unless description}}{{#with lambda.camelcase_param}}{{name}}{{/with}}{{/unless}}{{#with required}} (required){{/with}}{{#with defaultValue}} (default to {{.}}){{/with}}.</param>
+        /// <param name="{{#with lambda.camelcase_param}}{{name}}{{/with}}">{{#with description}}{{.}}{{else}}{{#with lambda.camelcase_param}}{{name}}{{/with}}{{/with}}{{#with required}} (required){{/with}}{{#with defaultValue}} (default to {{.}}){{/with}}.</param>
         {{/each}}
         {{#if hasOnlyReadOnly}}[JsonConstructorAttribute]{{/if}}
         public {{classname}}({{#each readWriteVars}}{{{datatypeWithEnum}}}{{#if isEnum}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}}{{/if}} {{#with lambda.camelcase_param}}{{name}}{{/with}} = {{#with defaultValue}}{{#unless isDateTime}}{{{defaultValue}}}{{/unless}}{{#if isDateTime}}default({{{datatypeWithEnum}}}){{/if}}{{/with}}{{#unless defaultValue}}default({{{datatypeWithEnum}}}{{#if isEnum}}{{#unless isContainer}}{{#unless required}}?{{/unless}}{{/unless}}{{/if}}){{/unless}}{{#unless @last}}, {{/unless}}{{/each}}){{#with parent}} : base({{#each parentVars}}{{#with lambda.camelcase_param}}{{name}}{{/with}}{{#unless @last}}, {{/unless}}{{/each}}){{/with}}
@@ -105,7 +105,7 @@
         }
 
         {{#each vars}}{{#unless isInherited}}{{#unless isEnum}}/// <summary>
-        /// {{description}}{{#unless description}}Gets or Sets {{{name}}}{{/unless}}
+        /// {{#with description}}{{.}}{{else}}Gets or Sets {{{name}}}{{/with}}
         /// </summary>{{#with description}}
         /// <value>{{.}}</value>{{/with}}
         {{#unless conditionalSerialization}}[DataMember(Name = "{{baseName}}"{{#with required}}, IsRequired = true{{/with}}, EmitDefaultValue = {{#with vendorExtensions.x-emit-default-value}}true{{/with}}{{#unless vendorExtensions.x-emit-default-value}}{{#if isBoolean}}true{{/if}}{{#unless isBoolean}}{{#if isNullable}}true{{/if}}{{#unless isNullable}}false{{/unless}}{{/unless}}{{/unless}})]

--- a/generate/templates/modelInnerEnum.handlebars
+++ b/generate/templates/modelInnerEnum.handlebars
@@ -1,5 +1,5 @@
         {{#unless isContainer}}/// <summary>
-        /// {{description}}{{#unless description}}Defines {{{name}}}{{/unless}}
+        /// {{#with description}}{{.}}{{else}}Defines {{{name}}}{{/with}}
         /// </summary>
         {{#with description}}/// <value>{{.}}</value>{{/with}}
         {{#if isString}}[JsonConverter(typeof(StringEnumConverter))]{{/if}}

--- a/generate/templates/modelOneOf.handlebars
+++ b/generate/templates/modelOneOf.handlebars
@@ -1,5 +1,5 @@
     /// <summary>
-    /// {{description}}{{#unless description}}{{classname}}{{/unless}}
+    /// {{#with description}}{{.}}{{else}}{{classname}}{{/with}}
     /// </summary>
     [JsonConverter(typeof({{classname}}JsonConverter))]
     [DataContract(Name = "{{{name}}}")]

--- a/generate/templates/model_doc.handlebars
+++ b/generate/templates/model_doc.handlebars
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 {{#with parent ~}}{{#each parentVars}}
-**{{name}}** | {{#if isPrimitiveType}}**{{dataType}}**{{/if}}{{#unless isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/unless}} | {{description}} | {{#unless required}}[optional] {{/unless}}{{#if isReadOnly}}[readonly] {{/if}}{{#with defaultValue}}[default to {{{.}}}]{{/with}}
+**{{name}}** | {{#if isPrimitiveType}}**{{dataType}}**{{/if}}{{#unless isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/unless}} | {{#if description}}{{description}}{{/if}} | {{#unless required}}[optional] {{/unless}}{{#if isReadOnly}}[readonly] {{/if}}{{#with defaultValue}}[default to {{{.}}}]{{/with}}
 {{/each}}{{/with ~}}
-{{#each vars}}**{{name}}** | {{#if isPrimitiveType}}**{{dataType}}**{{/if}}{{#unless isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/unless}} | {{description}} | {{#unless required}}[optional] {{/unless}}{{#if isReadOnly}}[readonly] {{/if}}{{#with defaultValue}}[default to {{{.}}}]{{/with}}
+{{#each vars}}**{{name}}** | {{#if isPrimitiveType}}**{{dataType}}**{{/if}}{{#unless isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/unless}} | {{#if description}}{{description}}{{/if}} | {{#unless required}}[optional] {{/unless}}{{#if isReadOnly}}[readonly] {{/if}}{{#with defaultValue}}[default to {{{.}}}]{{/with}}
 {{/each}}
 [[Back to Model list]](../{{#if useGenericHost}}../{{/if}}README.md#documentation-for-models) [[Back to API list]](../{{#if useGenericHost}}../{{/if}}README.md#documentation-for-api-endpoints) [[Back to README]](../{{#if useGenericHost}}../{{/if}}README.md)
 


### PR DESCRIPTION
This is the vault-client-dotnet counterpart to
hashicorp/vault-client-go#178.

Currently, if you run `make generate | grep 'Unregistered helper name'`
there are 16260 warnings due to endpoints missing various fields in their data models:
```
    192 [main] WARN  o.o.c.t.HandlebarsEngineAdapter - Unregistered helper name 'collectionFormat', processing template:
     54 [main] WARN  o.o.c.t.HandlebarsEngineAdapter - Unregistered helper name 'complexType', processing template:
   3369 [main] WARN  o.o.c.t.HandlebarsEngineAdapter - Unregistered helper name 'description', processing template:
    942 [main] WARN  o.o.c.t.HandlebarsEngineAdapter - Unregistered helper name 'mediaType', processing template:
   1600 [main] WARN  o.o.c.t.HandlebarsEngineAdapter - Unregistered helper name 'notes', processing template:
   7271 [main] WARN  o.o.c.t.HandlebarsEngineAdapter - Unregistered helper name 'returnType', processing template:
   2832 [main] WARN  o.o.c.t.HandlebarsEngineAdapter - Unregistered helper name 'summary', processing template:
```

The overwhelming number of warnings makes it harder to spot genuine
issues occurring.

This change wraps each unconditional reference to these fields in an
`{{#if}}` or `{{#with}}` to cure the warnings.

## How has this been tested?

Generation with the updated templates produces no changes to the output files.
