### PR TITLE
Specify packageGuid in openapi-generator config

### DIFF
--- a/generate/config.yaml
+++ b/generate/config.yaml
@@ -7,6 +7,7 @@ additionalProperties:
   packageCompany: Hashicorp
   packageName: Vault
   packageVersion: 0.1.0-beta
+  packageGuid: "{16184629-2991-4084-BCA4-2748275C24E5}"
 library: httpclient
 files:
   Client.mustache:


### PR DESCRIPTION
We must do this, otherwise a new GUID is generated for every run, leading to frequent meaningless changes in the generated `Vault.sln` file.

## How has this been tested?

`make regen`, confirm that `Vault.sln` contents now no longer changes every time.
