### PR TITLE
Sync OpenAPI; PkiConfigureAcmeRequest += AllowRoleExtKeyUsage

### DIFF
--- a/docs/PkiConfigureAcmeRequest.md
+++ b/docs/PkiConfigureAcmeRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**AllowRoleExtKeyUsage** | **bool** | whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth. | [optional] [default to false]
 **AllowedIssuers** | **List&lt;string&gt;** | which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer | [optional] 
 **AllowedRoles** | **List&lt;string&gt;** | which roles are allowed for use with ACME; by default via &#x27;*&#x27;, these will be all roles including sign-verbatim; when concrete role names are specified, any default_directory_policy role must be included to allow usage of the default acme directories under /pki/acme/directory and /pki/issuer/:issuer_id/acme/directory. | [optional] 
 **DefaultDirectoryPolicy** | **string** | the policy to be used for non-role-qualified ACME requests; by default ACME issuance will be otherwise unrestricted, equivalent to the sign-verbatim endpoint; one may also specify a role to use as this policy, as \&quot;role:&lt;role_name&gt;\&quot;, the specified role must be allowed by allowed_roles | [optional] [default to "sign-verbatim"]

--- a/openapi.json
+++ b/openapi.json
@@ -348,6 +348,7 @@
     },
     "/auth/token/revoke-orphan": {
       "description": "This endpoint will delete the token and orphan its child tokens.",
+      "x-vault-sudo": true,
       "post": {
         "summary": "This endpoint will delete the token and orphan its child tokens.",
         "operationId": "token-revoke-orphan",
@@ -14970,6 +14971,7 @@
     },
     "/sys/seal": {
       "description": "Seals the Vault.",
+      "x-vault-sudo": true,
       "post": {
         "summary": "Seal the Vault.",
         "operationId": "seal",
@@ -15031,6 +15033,7 @@
       }
     },
     "/sys/step-down": {
+      "x-vault-sudo": true,
       "post": {
         "summary": "Cause the node to give up active status.",
         "description": "This endpoint forces the node to give up active status. If the node does not have active status, this endpoint does nothing. Note that the node will sleep for ten seconds before attempting to grab the active lock again, but if no standby nodes grab the active lock in the interim, the same node may become the active node again.",
@@ -28299,7 +28302,6 @@
           "required": true
         }
       ],
-      "x-vault-createSupported": true,
       "get": {
         "summary": "Returns the size of the active cache",
         "operationId": "transit-read-cache-configuration",
@@ -38437,6 +38439,11 @@
       "PkiConfigureAcmeRequest": {
         "type": "object",
         "properties": {
+          "allow_role_ext_key_usage": {
+            "type": "boolean",
+            "description": "whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth.",
+            "default": false
+          },
           "allowed_issuers": {
             "type": "array",
             "description": "which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer",

--- a/src/Vault.Test/Model/PkiConfigureAcmeRequestTests.cs
+++ b/src/Vault.Test/Model/PkiConfigureAcmeRequestTests.cs
@@ -56,6 +56,15 @@ namespace Vault.Test.Model
 
 
         /// <summary>
+        /// Test the property 'AllowRoleExtKeyUsage'
+        /// </summary>
+        [Fact]
+        public void AllowRoleExtKeyUsageTest()
+        {
+            // TODO unit test for the property 'AllowRoleExtKeyUsage'
+        }
+
+        /// <summary>
         /// Test the property 'AllowedIssuers'
         /// </summary>
         [Fact]

--- a/src/Vault/Model/PkiConfigureAcmeRequest.cs
+++ b/src/Vault/Model/PkiConfigureAcmeRequest.cs
@@ -34,6 +34,8 @@ namespace Vault.Model
         /// Initializes a new instance of the <see cref="PkiConfigureAcmeRequest" /> class.
         /// </summary>
 
+        /// <param name="AllowRoleExtKeyUsage">whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth. (default to false).</param>
+
         /// <param name="AllowedIssuers">which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer.</param>
 
         /// <param name="AllowedRoles">which roles are allowed for use with ACME; by default via &#x27;*&#x27;, these will be all roles including sign-verbatim; when concrete role names are specified, any default_directory_policy role must be included to allow usage of the default acme directories under /pki/acme/directory and /pki/issuer/:issuer_id/acme/directory..</param>
@@ -47,8 +49,10 @@ namespace Vault.Model
         /// <param name="Enabled">whether ACME is enabled, defaults to false meaning that clusters will by default not get ACME support (default to false).</param>
 
 
-        public PkiConfigureAcmeRequest(List<string> AllowedIssuers = default(List<string>), List<string> AllowedRoles = default(List<string>), string DefaultDirectoryPolicy = "sign-verbatim", string DnsResolver = "", string EabPolicy = "always-required", bool Enabled = false)
+        public PkiConfigureAcmeRequest(bool AllowRoleExtKeyUsage = false, List<string> AllowedIssuers = default(List<string>), List<string> AllowedRoles = default(List<string>), string DefaultDirectoryPolicy = "sign-verbatim", string DnsResolver = "", string EabPolicy = "always-required", bool Enabled = false)
         {
+
+            this.AllowRoleExtKeyUsage = AllowRoleExtKeyUsage;
 
             this.AllowedIssuers = AllowedIssuers;
 
@@ -69,6 +73,15 @@ namespace Vault.Model
             this.Enabled = Enabled;
 
         }
+
+        /// <summary>
+        /// whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth.
+        /// </summary>
+        /// <value>whether the ExtKeyUsage field from a role is used, defaults to false meaning that certificate will be signed with ServerAuth.</value>
+        [DataMember(Name = "allow_role_ext_key_usage", EmitDefaultValue = true)]
+
+        public bool AllowRoleExtKeyUsage { get; set; }
+
 
         /// <summary>
         /// which issuers are allowed for use with ACME; by default, this will only be the primary (default) issuer
@@ -134,6 +147,7 @@ namespace Vault.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class PkiConfigureAcmeRequest {\n");
+            sb.Append("  AllowRoleExtKeyUsage: ").Append(AllowRoleExtKeyUsage).Append("\n");
             sb.Append("  AllowedIssuers: ").Append(AllowedIssuers).Append("\n");
             sb.Append("  AllowedRoles: ").Append(AllowedRoles).Append("\n");
             sb.Append("  DefaultDirectoryPolicy: ").Append(DefaultDirectoryPolicy).Append("\n");
@@ -175,6 +189,11 @@ namespace Vault.Model
                 return false;
             }
             return
+                (
+                    this.AllowRoleExtKeyUsage == input.AllowRoleExtKeyUsage ||
+
+                    this.AllowRoleExtKeyUsage.Equals(input.AllowRoleExtKeyUsage)
+                ) &&
                 (
                     this.AllowedIssuers == input.AllowedIssuers ||
                     this.AllowedIssuers != null &&
@@ -223,6 +242,8 @@ namespace Vault.Model
             {
                 int hashCode = 41;
 
+
+                hashCode = (hashCode * 59) + this.AllowRoleExtKeyUsage.GetHashCode();
                 if (this.AllowedIssuers != null)
                 {
                     hashCode = (hashCode * 59) + this.AllowedIssuers.GetHashCode();


### PR DESCRIPTION
Also some corrections to x-vault-sudo and x-vault-createSupported
metadata in the OpenAPI document that do not influence generation.

Normally I wouldn't bother creating a separate PR just for this, but
I have a few open Vault PRs that will result in larger cross-cutting
changes to the generated OpenAPI, so I thought it best to do this minor
sync first, so that these changes are not mingled with those upcoming
changes.
