### PR TITLE
Fix links in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,11 @@ and this project adheres to
 <!-- diffs -->
 
 [unreleased-diff]:
-  https://github.com/hashicorp/vault-client-dotnet/compare/0.1.0-beta...HEAD
+  https://github.com/hashicorp/vault-client-dotnet/compare/0.2.0...HEAD
 [0.2.0-diff]:
-  https://github.com/hashicorp/vault-client-dotnet/commits/0.2.0
+  https://github.com/hashicorp/vault-client-dotnet/compare/0.1.0...0.2.0
 [0.1.0-diff]:
-  https://github.com/hashicorp/vault-client-dotnet/commits/0.1.0
+  https://github.com/hashicorp/vault-client-dotnet/compare/0.1.0-beta...0.1.0
 [0.1.0-beta-diff]:
   https://github.com/hashicorp/vault-client-dotnet/commits/0.1.0-beta
 


### PR DESCRIPTION
There was an incorrect tag name in the unreleased link, and I also
converted them all to to the same style of URL as used in
vault-client-go.
