### PR TITLE
Sync OpenAPI: Changes to PKI sign responses

### DIFF
--- a/docs/PkiIssuerSignVerbatimResponse.md
+++ b/docs/PkiIssuerSignVerbatimResponse.md
@@ -8,8 +8,6 @@ Name | Type | Description | Notes
 **Certificate** | **string** | Certificate | [optional] 
 **Expiration** | **long** | Time of expiration | [optional] 
 **IssuingCa** | **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | **string** | Private key | [optional] 
-**PrivateKeyType** | **string** | Private key type | [optional] 
 **SerialNumber** | **string** | Serial Number | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/PkiIssuerSignVerbatimWithRoleResponse.md
+++ b/docs/PkiIssuerSignVerbatimWithRoleResponse.md
@@ -8,8 +8,6 @@ Name | Type | Description | Notes
 **Certificate** | **string** | Certificate | [optional] 
 **Expiration** | **long** | Time of expiration | [optional] 
 **IssuingCa** | **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | **string** | Private key | [optional] 
-**PrivateKeyType** | **string** | Private key type | [optional] 
 **SerialNumber** | **string** | Serial Number | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/PkiIssuerSignWithRoleResponse.md
+++ b/docs/PkiIssuerSignWithRoleResponse.md
@@ -8,8 +8,6 @@ Name | Type | Description | Notes
 **Certificate** | **string** | Certificate | [optional] 
 **Expiration** | **long** | Time of expiration | [optional] 
 **IssuingCa** | **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | **string** | Private key | [optional] 
-**PrivateKeyType** | **string** | Private key type | [optional] 
 **SerialNumber** | **string** | Serial Number | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/PkiSignVerbatimResponse.md
+++ b/docs/PkiSignVerbatimResponse.md
@@ -8,8 +8,6 @@ Name | Type | Description | Notes
 **Certificate** | **string** | Certificate | [optional] 
 **Expiration** | **long** | Time of expiration | [optional] 
 **IssuingCa** | **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | **string** | Private key | [optional] 
-**PrivateKeyType** | **string** | Private key type | [optional] 
 **SerialNumber** | **string** | Serial Number | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/PkiSignVerbatimWithRoleResponse.md
+++ b/docs/PkiSignVerbatimWithRoleResponse.md
@@ -8,8 +8,6 @@ Name | Type | Description | Notes
 **Certificate** | **string** | Certificate | [optional] 
 **Expiration** | **long** | Time of expiration | [optional] 
 **IssuingCa** | **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | **string** | Private key | [optional] 
-**PrivateKeyType** | **string** | Private key type | [optional] 
 **SerialNumber** | **string** | Serial Number | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/PkiSignWithRoleResponse.md
+++ b/docs/PkiSignWithRoleResponse.md
@@ -8,8 +8,6 @@ Name | Type | Description | Notes
 **Certificate** | **string** | Certificate | [optional] 
 **Expiration** | **long** | Time of expiration | [optional] 
 **IssuingCa** | **string** | Issuing Certificate Authority | [optional] 
-**PrivateKey** | **string** | Private key | [optional] 
-**PrivateKeyType** | **string** | Private key type | [optional] 
 **SerialNumber** | **string** | Serial Number | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/openapi.json
+++ b/openapi.json
@@ -41558,14 +41558,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -41752,14 +41744,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -41905,14 +41889,6 @@
           "issuing_ca": {
             "type": "string",
             "description": "Issuing Certificate Authority"
-          },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
           },
           "serial_number": {
             "type": "string",
@@ -44858,14 +44834,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -45057,14 +45025,6 @@
             "type": "string",
             "description": "Issuing Certificate Authority"
           },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
-          },
           "serial_number": {
             "type": "string",
             "description": "Serial Number"
@@ -45215,14 +45175,6 @@
           "issuing_ca": {
             "type": "string",
             "description": "Issuing Certificate Authority"
-          },
-          "private_key": {
-            "type": "string",
-            "description": "Private key"
-          },
-          "private_key_type": {
-            "type": "string",
-            "description": "Private key type"
           },
           "serial_number": {
             "type": "string",

--- a/src/Vault/Model/PkiIssuerSignVerbatimResponse.cs
+++ b/src/Vault/Model/PkiIssuerSignVerbatimResponse.cs
@@ -42,14 +42,10 @@ namespace Vault.Model
 
         /// <param name="IssuingCa">Issuing Certificate Authority.</param>
 
-        /// <param name="PrivateKey">Private key.</param>
-
-        /// <param name="PrivateKeyType">Private key type.</param>
-
         /// <param name="SerialNumber">Serial Number.</param>
 
 
-        public PkiIssuerSignVerbatimResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string PrivateKey = default(string), string PrivateKeyType = default(string), string SerialNumber = default(string))
+        public PkiIssuerSignVerbatimResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string SerialNumber = default(string))
         {
 
             this.CaChain = CaChain;
@@ -59,10 +55,6 @@ namespace Vault.Model
             this.Expiration = Expiration;
 
             this.IssuingCa = IssuingCa;
-
-            this.PrivateKey = PrivateKey;
-
-            this.PrivateKeyType = PrivateKeyType;
 
             this.SerialNumber = SerialNumber;
 
@@ -105,24 +97,6 @@ namespace Vault.Model
 
 
         /// <summary>
-        /// Private key
-        /// </summary>
-        /// <value>Private key</value>
-        [DataMember(Name = "private_key", EmitDefaultValue = false)]
-
-        public string PrivateKey { get; set; }
-
-
-        /// <summary>
-        /// Private key type
-        /// </summary>
-        /// <value>Private key type</value>
-        [DataMember(Name = "private_key_type", EmitDefaultValue = false)]
-
-        public string PrivateKeyType { get; set; }
-
-
-        /// <summary>
         /// Serial Number
         /// </summary>
         /// <value>Serial Number</value>
@@ -145,8 +119,6 @@ namespace Vault.Model
             sb.Append("  Certificate: ").Append(Certificate).Append("\n");
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  IssuingCa: ").Append(IssuingCa).Append("\n");
-            sb.Append("  PrivateKey: ").Append(PrivateKey).Append("\n");
-            sb.Append("  PrivateKeyType: ").Append(PrivateKeyType).Append("\n");
             sb.Append("  SerialNumber: ").Append(SerialNumber).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -207,18 +179,6 @@ namespace Vault.Model
 
                 ) &&
                 (
-                    this.PrivateKey == input.PrivateKey ||
-                    (this.PrivateKey != null &&
-                    this.PrivateKey.Equals(input.PrivateKey))
-
-                ) &&
-                (
-                    this.PrivateKeyType == input.PrivateKeyType ||
-                    (this.PrivateKeyType != null &&
-                    this.PrivateKeyType.Equals(input.PrivateKeyType))
-
-                ) &&
-                (
                     this.SerialNumber == input.SerialNumber ||
                     (this.SerialNumber != null &&
                     this.SerialNumber.Equals(input.SerialNumber))
@@ -252,16 +212,6 @@ namespace Vault.Model
                 if (this.IssuingCa != null)
                 {
                     hashCode = (hashCode * 59) + this.IssuingCa.GetHashCode();
-                }
-
-                if (this.PrivateKey != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKey.GetHashCode();
-                }
-
-                if (this.PrivateKeyType != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKeyType.GetHashCode();
                 }
 
                 if (this.SerialNumber != null)

--- a/src/Vault/Model/PkiIssuerSignVerbatimWithRoleResponse.cs
+++ b/src/Vault/Model/PkiIssuerSignVerbatimWithRoleResponse.cs
@@ -42,14 +42,10 @@ namespace Vault.Model
 
         /// <param name="IssuingCa">Issuing Certificate Authority.</param>
 
-        /// <param name="PrivateKey">Private key.</param>
-
-        /// <param name="PrivateKeyType">Private key type.</param>
-
         /// <param name="SerialNumber">Serial Number.</param>
 
 
-        public PkiIssuerSignVerbatimWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string PrivateKey = default(string), string PrivateKeyType = default(string), string SerialNumber = default(string))
+        public PkiIssuerSignVerbatimWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string SerialNumber = default(string))
         {
 
             this.CaChain = CaChain;
@@ -59,10 +55,6 @@ namespace Vault.Model
             this.Expiration = Expiration;
 
             this.IssuingCa = IssuingCa;
-
-            this.PrivateKey = PrivateKey;
-
-            this.PrivateKeyType = PrivateKeyType;
 
             this.SerialNumber = SerialNumber;
 
@@ -105,24 +97,6 @@ namespace Vault.Model
 
 
         /// <summary>
-        /// Private key
-        /// </summary>
-        /// <value>Private key</value>
-        [DataMember(Name = "private_key", EmitDefaultValue = false)]
-
-        public string PrivateKey { get; set; }
-
-
-        /// <summary>
-        /// Private key type
-        /// </summary>
-        /// <value>Private key type</value>
-        [DataMember(Name = "private_key_type", EmitDefaultValue = false)]
-
-        public string PrivateKeyType { get; set; }
-
-
-        /// <summary>
         /// Serial Number
         /// </summary>
         /// <value>Serial Number</value>
@@ -145,8 +119,6 @@ namespace Vault.Model
             sb.Append("  Certificate: ").Append(Certificate).Append("\n");
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  IssuingCa: ").Append(IssuingCa).Append("\n");
-            sb.Append("  PrivateKey: ").Append(PrivateKey).Append("\n");
-            sb.Append("  PrivateKeyType: ").Append(PrivateKeyType).Append("\n");
             sb.Append("  SerialNumber: ").Append(SerialNumber).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -207,18 +179,6 @@ namespace Vault.Model
 
                 ) &&
                 (
-                    this.PrivateKey == input.PrivateKey ||
-                    (this.PrivateKey != null &&
-                    this.PrivateKey.Equals(input.PrivateKey))
-
-                ) &&
-                (
-                    this.PrivateKeyType == input.PrivateKeyType ||
-                    (this.PrivateKeyType != null &&
-                    this.PrivateKeyType.Equals(input.PrivateKeyType))
-
-                ) &&
-                (
                     this.SerialNumber == input.SerialNumber ||
                     (this.SerialNumber != null &&
                     this.SerialNumber.Equals(input.SerialNumber))
@@ -252,16 +212,6 @@ namespace Vault.Model
                 if (this.IssuingCa != null)
                 {
                     hashCode = (hashCode * 59) + this.IssuingCa.GetHashCode();
-                }
-
-                if (this.PrivateKey != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKey.GetHashCode();
-                }
-
-                if (this.PrivateKeyType != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKeyType.GetHashCode();
                 }
 
                 if (this.SerialNumber != null)

--- a/src/Vault/Model/PkiIssuerSignWithRoleResponse.cs
+++ b/src/Vault/Model/PkiIssuerSignWithRoleResponse.cs
@@ -42,14 +42,10 @@ namespace Vault.Model
 
         /// <param name="IssuingCa">Issuing Certificate Authority.</param>
 
-        /// <param name="PrivateKey">Private key.</param>
-
-        /// <param name="PrivateKeyType">Private key type.</param>
-
         /// <param name="SerialNumber">Serial Number.</param>
 
 
-        public PkiIssuerSignWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string PrivateKey = default(string), string PrivateKeyType = default(string), string SerialNumber = default(string))
+        public PkiIssuerSignWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string SerialNumber = default(string))
         {
 
             this.CaChain = CaChain;
@@ -59,10 +55,6 @@ namespace Vault.Model
             this.Expiration = Expiration;
 
             this.IssuingCa = IssuingCa;
-
-            this.PrivateKey = PrivateKey;
-
-            this.PrivateKeyType = PrivateKeyType;
 
             this.SerialNumber = SerialNumber;
 
@@ -105,24 +97,6 @@ namespace Vault.Model
 
 
         /// <summary>
-        /// Private key
-        /// </summary>
-        /// <value>Private key</value>
-        [DataMember(Name = "private_key", EmitDefaultValue = false)]
-
-        public string PrivateKey { get; set; }
-
-
-        /// <summary>
-        /// Private key type
-        /// </summary>
-        /// <value>Private key type</value>
-        [DataMember(Name = "private_key_type", EmitDefaultValue = false)]
-
-        public string PrivateKeyType { get; set; }
-
-
-        /// <summary>
         /// Serial Number
         /// </summary>
         /// <value>Serial Number</value>
@@ -145,8 +119,6 @@ namespace Vault.Model
             sb.Append("  Certificate: ").Append(Certificate).Append("\n");
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  IssuingCa: ").Append(IssuingCa).Append("\n");
-            sb.Append("  PrivateKey: ").Append(PrivateKey).Append("\n");
-            sb.Append("  PrivateKeyType: ").Append(PrivateKeyType).Append("\n");
             sb.Append("  SerialNumber: ").Append(SerialNumber).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -207,18 +179,6 @@ namespace Vault.Model
 
                 ) &&
                 (
-                    this.PrivateKey == input.PrivateKey ||
-                    (this.PrivateKey != null &&
-                    this.PrivateKey.Equals(input.PrivateKey))
-
-                ) &&
-                (
-                    this.PrivateKeyType == input.PrivateKeyType ||
-                    (this.PrivateKeyType != null &&
-                    this.PrivateKeyType.Equals(input.PrivateKeyType))
-
-                ) &&
-                (
                     this.SerialNumber == input.SerialNumber ||
                     (this.SerialNumber != null &&
                     this.SerialNumber.Equals(input.SerialNumber))
@@ -252,16 +212,6 @@ namespace Vault.Model
                 if (this.IssuingCa != null)
                 {
                     hashCode = (hashCode * 59) + this.IssuingCa.GetHashCode();
-                }
-
-                if (this.PrivateKey != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKey.GetHashCode();
-                }
-
-                if (this.PrivateKeyType != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKeyType.GetHashCode();
                 }
 
                 if (this.SerialNumber != null)

--- a/src/Vault/Model/PkiSignVerbatimResponse.cs
+++ b/src/Vault/Model/PkiSignVerbatimResponse.cs
@@ -42,14 +42,10 @@ namespace Vault.Model
 
         /// <param name="IssuingCa">Issuing Certificate Authority.</param>
 
-        /// <param name="PrivateKey">Private key.</param>
-
-        /// <param name="PrivateKeyType">Private key type.</param>
-
         /// <param name="SerialNumber">Serial Number.</param>
 
 
-        public PkiSignVerbatimResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string PrivateKey = default(string), string PrivateKeyType = default(string), string SerialNumber = default(string))
+        public PkiSignVerbatimResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string SerialNumber = default(string))
         {
 
             this.CaChain = CaChain;
@@ -59,10 +55,6 @@ namespace Vault.Model
             this.Expiration = Expiration;
 
             this.IssuingCa = IssuingCa;
-
-            this.PrivateKey = PrivateKey;
-
-            this.PrivateKeyType = PrivateKeyType;
 
             this.SerialNumber = SerialNumber;
 
@@ -105,24 +97,6 @@ namespace Vault.Model
 
 
         /// <summary>
-        /// Private key
-        /// </summary>
-        /// <value>Private key</value>
-        [DataMember(Name = "private_key", EmitDefaultValue = false)]
-
-        public string PrivateKey { get; set; }
-
-
-        /// <summary>
-        /// Private key type
-        /// </summary>
-        /// <value>Private key type</value>
-        [DataMember(Name = "private_key_type", EmitDefaultValue = false)]
-
-        public string PrivateKeyType { get; set; }
-
-
-        /// <summary>
         /// Serial Number
         /// </summary>
         /// <value>Serial Number</value>
@@ -145,8 +119,6 @@ namespace Vault.Model
             sb.Append("  Certificate: ").Append(Certificate).Append("\n");
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  IssuingCa: ").Append(IssuingCa).Append("\n");
-            sb.Append("  PrivateKey: ").Append(PrivateKey).Append("\n");
-            sb.Append("  PrivateKeyType: ").Append(PrivateKeyType).Append("\n");
             sb.Append("  SerialNumber: ").Append(SerialNumber).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -207,18 +179,6 @@ namespace Vault.Model
 
                 ) &&
                 (
-                    this.PrivateKey == input.PrivateKey ||
-                    (this.PrivateKey != null &&
-                    this.PrivateKey.Equals(input.PrivateKey))
-
-                ) &&
-                (
-                    this.PrivateKeyType == input.PrivateKeyType ||
-                    (this.PrivateKeyType != null &&
-                    this.PrivateKeyType.Equals(input.PrivateKeyType))
-
-                ) &&
-                (
                     this.SerialNumber == input.SerialNumber ||
                     (this.SerialNumber != null &&
                     this.SerialNumber.Equals(input.SerialNumber))
@@ -252,16 +212,6 @@ namespace Vault.Model
                 if (this.IssuingCa != null)
                 {
                     hashCode = (hashCode * 59) + this.IssuingCa.GetHashCode();
-                }
-
-                if (this.PrivateKey != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKey.GetHashCode();
-                }
-
-                if (this.PrivateKeyType != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKeyType.GetHashCode();
                 }
 
                 if (this.SerialNumber != null)

--- a/src/Vault/Model/PkiSignVerbatimWithRoleResponse.cs
+++ b/src/Vault/Model/PkiSignVerbatimWithRoleResponse.cs
@@ -42,14 +42,10 @@ namespace Vault.Model
 
         /// <param name="IssuingCa">Issuing Certificate Authority.</param>
 
-        /// <param name="PrivateKey">Private key.</param>
-
-        /// <param name="PrivateKeyType">Private key type.</param>
-
         /// <param name="SerialNumber">Serial Number.</param>
 
 
-        public PkiSignVerbatimWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string PrivateKey = default(string), string PrivateKeyType = default(string), string SerialNumber = default(string))
+        public PkiSignVerbatimWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string SerialNumber = default(string))
         {
 
             this.CaChain = CaChain;
@@ -59,10 +55,6 @@ namespace Vault.Model
             this.Expiration = Expiration;
 
             this.IssuingCa = IssuingCa;
-
-            this.PrivateKey = PrivateKey;
-
-            this.PrivateKeyType = PrivateKeyType;
 
             this.SerialNumber = SerialNumber;
 
@@ -105,24 +97,6 @@ namespace Vault.Model
 
 
         /// <summary>
-        /// Private key
-        /// </summary>
-        /// <value>Private key</value>
-        [DataMember(Name = "private_key", EmitDefaultValue = false)]
-
-        public string PrivateKey { get; set; }
-
-
-        /// <summary>
-        /// Private key type
-        /// </summary>
-        /// <value>Private key type</value>
-        [DataMember(Name = "private_key_type", EmitDefaultValue = false)]
-
-        public string PrivateKeyType { get; set; }
-
-
-        /// <summary>
         /// Serial Number
         /// </summary>
         /// <value>Serial Number</value>
@@ -145,8 +119,6 @@ namespace Vault.Model
             sb.Append("  Certificate: ").Append(Certificate).Append("\n");
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  IssuingCa: ").Append(IssuingCa).Append("\n");
-            sb.Append("  PrivateKey: ").Append(PrivateKey).Append("\n");
-            sb.Append("  PrivateKeyType: ").Append(PrivateKeyType).Append("\n");
             sb.Append("  SerialNumber: ").Append(SerialNumber).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -207,18 +179,6 @@ namespace Vault.Model
 
                 ) &&
                 (
-                    this.PrivateKey == input.PrivateKey ||
-                    (this.PrivateKey != null &&
-                    this.PrivateKey.Equals(input.PrivateKey))
-
-                ) &&
-                (
-                    this.PrivateKeyType == input.PrivateKeyType ||
-                    (this.PrivateKeyType != null &&
-                    this.PrivateKeyType.Equals(input.PrivateKeyType))
-
-                ) &&
-                (
                     this.SerialNumber == input.SerialNumber ||
                     (this.SerialNumber != null &&
                     this.SerialNumber.Equals(input.SerialNumber))
@@ -252,16 +212,6 @@ namespace Vault.Model
                 if (this.IssuingCa != null)
                 {
                     hashCode = (hashCode * 59) + this.IssuingCa.GetHashCode();
-                }
-
-                if (this.PrivateKey != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKey.GetHashCode();
-                }
-
-                if (this.PrivateKeyType != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKeyType.GetHashCode();
                 }
 
                 if (this.SerialNumber != null)

--- a/src/Vault/Model/PkiSignWithRoleResponse.cs
+++ b/src/Vault/Model/PkiSignWithRoleResponse.cs
@@ -42,14 +42,10 @@ namespace Vault.Model
 
         /// <param name="IssuingCa">Issuing Certificate Authority.</param>
 
-        /// <param name="PrivateKey">Private key.</param>
-
-        /// <param name="PrivateKeyType">Private key type.</param>
-
         /// <param name="SerialNumber">Serial Number.</param>
 
 
-        public PkiSignWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string PrivateKey = default(string), string PrivateKeyType = default(string), string SerialNumber = default(string))
+        public PkiSignWithRoleResponse(List<string> CaChain = default(List<string>), string Certificate = default(string), long Expiration = default(long), string IssuingCa = default(string), string SerialNumber = default(string))
         {
 
             this.CaChain = CaChain;
@@ -59,10 +55,6 @@ namespace Vault.Model
             this.Expiration = Expiration;
 
             this.IssuingCa = IssuingCa;
-
-            this.PrivateKey = PrivateKey;
-
-            this.PrivateKeyType = PrivateKeyType;
 
             this.SerialNumber = SerialNumber;
 
@@ -105,24 +97,6 @@ namespace Vault.Model
 
 
         /// <summary>
-        /// Private key
-        /// </summary>
-        /// <value>Private key</value>
-        [DataMember(Name = "private_key", EmitDefaultValue = false)]
-
-        public string PrivateKey { get; set; }
-
-
-        /// <summary>
-        /// Private key type
-        /// </summary>
-        /// <value>Private key type</value>
-        [DataMember(Name = "private_key_type", EmitDefaultValue = false)]
-
-        public string PrivateKeyType { get; set; }
-
-
-        /// <summary>
         /// Serial Number
         /// </summary>
         /// <value>Serial Number</value>
@@ -145,8 +119,6 @@ namespace Vault.Model
             sb.Append("  Certificate: ").Append(Certificate).Append("\n");
             sb.Append("  Expiration: ").Append(Expiration).Append("\n");
             sb.Append("  IssuingCa: ").Append(IssuingCa).Append("\n");
-            sb.Append("  PrivateKey: ").Append(PrivateKey).Append("\n");
-            sb.Append("  PrivateKeyType: ").Append(PrivateKeyType).Append("\n");
             sb.Append("  SerialNumber: ").Append(SerialNumber).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -207,18 +179,6 @@ namespace Vault.Model
 
                 ) &&
                 (
-                    this.PrivateKey == input.PrivateKey ||
-                    (this.PrivateKey != null &&
-                    this.PrivateKey.Equals(input.PrivateKey))
-
-                ) &&
-                (
-                    this.PrivateKeyType == input.PrivateKeyType ||
-                    (this.PrivateKeyType != null &&
-                    this.PrivateKeyType.Equals(input.PrivateKeyType))
-
-                ) &&
-                (
                     this.SerialNumber == input.SerialNumber ||
                     (this.SerialNumber != null &&
                     this.SerialNumber.Equals(input.SerialNumber))
@@ -252,16 +212,6 @@ namespace Vault.Model
                 if (this.IssuingCa != null)
                 {
                     hashCode = (hashCode * 59) + this.IssuingCa.GetHashCode();
-                }
-
-                if (this.PrivateKey != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKey.GetHashCode();
-                }
-
-                if (this.PrivateKeyType != null)
-                {
-                    hashCode = (hashCode * 59) + this.PrivateKeyType.GetHashCode();
                 }
 
                 if (this.SerialNumber != null)


### PR DESCRIPTION
Removes an incorrect field from some responses, from
hashicorp/vault#22053.
