### PR TITLE
BuildUserAgent method support OS name parsing with and without spaces

### DIFF
--- a/generate/templates/Configuration.handlebars
+++ b/generate/templates/Configuration.handlebars
@@ -351,7 +351,7 @@ namespace {{packageName}}.Client
         public string BuildUserAgent()
         {
             StringBuilder sb = new StringBuilder("vault-client-dotnet/");
-            string OSName = RuntimeInformation.OSDescription.Substring(0, RuntimeInformation.OSDescription.IndexOf(" "));
+            string OSName = RuntimeInformation.OSDescription.Contains(" ") ? RuntimeInformation.OSDescription.Substring(0, RuntimeInformation.OSDescription.IndexOf(" ")) : RuntimeInformation.OSDescription;
             sb.AppendFormat("{0} ({1} {2}; .Net {3})", Version, OSName, RuntimeInformation.ProcessArchitecture, System.Environment.Version);
             return sb.ToString();
         }

--- a/src/Vault/Client/Configuration.cs
+++ b/src/Vault/Client/Configuration.cs
@@ -338,7 +338,7 @@ namespace Vault.Client
         public string BuildUserAgent()
         {
             StringBuilder sb = new StringBuilder("vault-client-dotnet/");
-            string OSName = RuntimeInformation.OSDescription.Substring(0, RuntimeInformation.OSDescription.IndexOf(" "));
+            string OSName = RuntimeInformation.OSDescription.Contains(" ") ? RuntimeInformation.OSDescription.Substring(0, RuntimeInformation.OSDescription.IndexOf(" ")) : RuntimeInformation.OSDescription;
             sb.AppendFormat("{0} ({1} {2}; .Net {3})", Version, OSName, RuntimeInformation.ProcessArchitecture, System.Environment.Version);
             return sb.ToString();
         }


### PR DESCRIPTION
## Description

> Checks if the OSDescription contains space if yes return the distro name else the entire string

Resolves https://github.com/hashicorp/vault-client-dotnet/issues/205

## How has this been tested?
- Ran on aspnet-runtime-fips chainguard image where the PRETTY_NAME="Chainguard"

